### PR TITLE
test(app): add SlaBreachHandlerWiringTest — verify CDI displacement and handler event routing

### DIFF
--- a/LAYER-LOG.md
+++ b/LAYER-LOG.md
@@ -144,7 +144,7 @@ These were in the original Gastown-derived 13-tag vocabulary and removed. They a
 **Completed:** Epic 3 (devtown#10) shipped 2026-05-19
 **Issues:** casehubio/devtown#10 (Epic 3: PR review CasePlanModel — content-driven routing and parallel checks)
 **Design specs:** `docs/specs/2026-05-15-epic3-pr-review-caseplanmodel-design.md`
-**Blog:** `blog/2026-05-19-mdp01-from-naive-to-adaptive.md` 🔲 (not yet drafted)
+**Blog:** `blog/2026-05-19-mdp01-layer-5-case-definition-lands.md`
 **Improvement log:** `docs/PROGRESS.md` — DT entries to be added as improvement decisions are formalised
 
 **Key files:**

--- a/app/src/test/java/io/casehub/devtown/app/SlaBreachHandlerWiringTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/SlaBreachHandlerWiringTest.java
@@ -1,0 +1,75 @@
+package io.casehub.devtown.app;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.engine.spi.CaseInstanceRepository;
+import io.casehub.platform.api.path.Path;
+import io.casehub.platform.api.preferences.MapPreferences;
+import io.casehub.work.api.BreachDecision;
+import io.casehub.work.api.BreachType;
+import io.casehub.work.api.BreachedTask;
+import io.casehub.work.api.SlaBreachContext;
+import io.casehub.work.api.SlaBreachPolicy;
+import io.casehub.work.runtime.event.SlaBreachEvent;
+import io.casehub.workadapter.CallerRef;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class SlaBreachHandlerWiringTest {
+
+    @Inject SlaBreachPolicy        policy;
+    @Inject PrReviewCaseHub        caseHub;
+    @Inject Event<SlaBreachEvent>  breachEvents;
+    @Inject CaseInstanceRepository caseInstanceRepository;
+
+    // linesChanged=100 < humanApprovalThreshold=500 — human-approval binding does not fire.
+    // All other bindings suppressed by pre-seeding (PP-20260521-134c38).
+    // Case stays active: pr-approved goal requires styleCheck.outcome==APPROVED but it is PENDING.
+    private static final Map<String, Object> MINIMAL_CTX = Map.of(
+            "pr",                  Map.of("id", "wt1", "repo", "r", "linesChanged", 100,
+                                           "baseRef", "main", "headSha", "abc"),
+            "policy",              Map.of("humanApprovalThreshold", 500,
+                                          "securityReviewRequired", false,
+                                          "requireSeniorApproval", false),
+            "codeAnalysis",        Map.of("complete", true, "securitySensitive", false,
+                                           "architectureCrossing", false),
+            "styleCheck",          Map.of("outcome", "PENDING"),
+            "testCoverage",        Map.of("outcome", "PENDING"),
+            "performanceAnalysis", Map.of("outcome", "PENDING"),
+            "ci",                  Map.of("status", "passing"));
+
+    @Test
+    void slaBreachPolicyBean_displaces_noOp() {
+        assertThat(policy).isInstanceOf(SlaBreachPolicyBean.class);
+    }
+
+    @Test
+    void slaBreachHandler_onFail_signalsCaseContext() throws Exception {
+        UUID caseId = caseHub.startCase(MINIMAL_CTX).toCompletableFuture().get(5, SECONDS);
+        assertThat(caseId).isNotNull();
+
+        String callerRef = CallerRef.encode(caseId, "human-approval");
+        var task = new BreachedTask(UUID.randomUUID(), callerRef,
+                                    "PR approval", Set.of("pr-leads"));
+        var ctx  = new SlaBreachContext(BreachType.CLAIM_EXPIRED, task,
+                                        Path.root(), new MapPreferences(Map.of()));
+        breachEvents.fire(new SlaBreachEvent(ctx, new BreachDecision.Fail("sla-breach")));
+
+        await().atMost(5, SECONDS).pollInterval(100, MILLISECONDS).untilAsserted(() -> {
+            var instance = caseInstanceRepository.findByUuid(caseId)
+                    .await().atMost(Duration.ofSeconds(2));
+            assertThat(instance.getCaseContext().getPath("humanApproval.status"))
+                    .isEqualTo("sla-breach");
+        });
+    }
+}

--- a/docs/specs/2026-05-25-sla-breach-handler-wiring-test-design.md
+++ b/docs/specs/2026-05-25-sla-breach-handler-wiring-test-design.md
@@ -66,7 +66,7 @@ void slaBreachHandler_onFail_signalsCaseContext() throws Exception {
     var task = new BreachedTask(UUID.randomUUID(), callerRef,
                                 "PR approval", Set.of("pr-leads"));
     var ctx  = new SlaBreachContext(BreachType.CLAIM_EXPIRED, task,
-                                    Path.root(), MapPreferences.empty());
+                                    Path.root(), new MapPreferences(Map.of()));
     breachEvents.fire(new SlaBreachEvent(ctx, new BreachDecision.Fail("sla-breach")));
 
     await().atMost(3, SECONDS).pollInterval(100, MILLISECONDS).untilAsserted(() -> {

--- a/docs/specs/2026-05-25-sla-breach-handler-wiring-test-design.md
+++ b/docs/specs/2026-05-25-sla-breach-handler-wiring-test-design.md
@@ -1,0 +1,149 @@
+# SlaBreachHandlerWiringTest — Design Spec
+
+**Issue:** casehubio/devtown#42
+**Date:** 2026-05-25
+
+---
+
+## Problem
+
+`SlaBreachLifecycleTest` covers the full SLA breach chain end-to-end, but a failure there
+can be caused by many things: WorkItem not created, YAML config wrong, expiry detection
+broken, two-tier escalation logic wrong, handler wiring broken. A focused wiring test gives
+faster, clearer failure messages specifically when CDI displacement breaks.
+
+---
+
+## What Needs Wiring Verification
+
+Two independent CDI concerns in devtown-app:
+
+1. **CDI displacement:** `SlaBreachPolicyBean @ApplicationScoped` (no `@DefaultBean`) must
+   displace `NoOpSlaBreachPolicy @DefaultBean @ApplicationScoped` from casehub-work-runtime.
+   If `SlaBreachPolicyBean` is absent or mis-annotated, the runtime's NoOp fires silently
+   without escalation.
+
+2. **Handler event routing:** `SlaBreachHandler @Observes SlaBreachEvent` must receive the
+   CDI event and call `PrReviewCaseHub.signal()` on `BreachDecision.Fail`. If the annotation
+   is removed, changed to `@ObservesAsync`, or the injection of `PrReviewCaseHub` fails,
+   the case is never signaled.
+
+---
+
+## Design
+
+Single `@QuarkusTest` class, two test methods. No `@Alternative` static inner classes,
+no `selected-alternatives` changes.
+
+### Test 1 — CDI displacement
+
+```java
+@Inject SlaBreachPolicy policy;
+
+@Test
+void slaBreachPolicyBean_displaces_noOp() {
+    assertThat(policy).isInstanceOf(SlaBreachPolicyBean.class);
+}
+```
+
+CDI resolves the `@Default` `SlaBreachPolicy` bean. `SlaBreachPolicyBean @ApplicationScoped`
+(no `@DefaultBean`) beats `NoOpSlaBreachPolicy @DefaultBean @ApplicationScoped`. If
+`SlaBreachPolicyBean` is missing or mis-annotated, this test fails at startup
+(`UnsatisfiedResolutionException`) or at assertion.
+
+### Test 2 — Handler wiring
+
+```java
+@Inject PrReviewCaseHub        caseHub;
+@Inject Event<SlaBreachEvent>  breachEvents;
+@Inject CaseInstanceRepository caseInstanceRepository;
+
+@Test
+void slaBreachHandler_onFail_signalsCaseContext() throws Exception {
+    UUID caseId = caseHub.startCase(MINIMAL_CTX).toCompletableFuture().get(5, SECONDS);
+
+    String callerRef = CallerRef.encode(caseId, "human-approval");
+    var task = new BreachedTask(UUID.randomUUID(), callerRef,
+                                "PR approval", Set.of("pr-leads"));
+    var ctx  = new SlaBreachContext(BreachType.CLAIM_EXPIRED, task,
+                                    Path.root(), MapPreferences.empty());
+    breachEvents.fire(new SlaBreachEvent(ctx, new BreachDecision.Fail("sla-breach")));
+
+    await().atMost(3, SECONDS).pollInterval(100, MILLISECONDS).untilAsserted(() -> {
+        var instance = caseInstanceRepository.findByUuid(caseId)
+                .await().atMost(Duration.ofSeconds(2));
+        assertThat(instance.getCaseContext().getPath("humanApproval.status"))
+                .isEqualTo("sla-breach");
+    });
+}
+```
+
+`SlaBreachEvent` is fired directly — `ExpiryLifecycleService` is bypassed entirely.
+`@Observes` (synchronous CDI) means the handler completes before `fire()` returns, but
+`caseHub.signal()` may trigger async engine writes, so `await` is kept.
+
+### Minimal context — why `linesChanged=100`
+
+`MINIMAL_CTX` uses `linesChanged=100` (below `humanApprovalThreshold=500`). With the
+pr-review YAML, this means all eight bindings are inactive when the case starts:
+
+- `codeAnalysis`, `ci`, `styleCheck`, `testCoverage`, `performanceAnalysis` are pre-seeded
+  (non-null) — suppresses those bindings (PP-20260521-134c38)
+- `securitySensitive=false`, `architectureCrossing=false` — suppresses those bindings
+- `linesChanged=100 ≤ 500=threshold` — suppresses `human-approval` binding
+
+No async binding activity after `startCase()` resolves. Case stays active because `pr-approved`
+goal requires `styleCheck.outcome == "APPROVED"` but it is `PENDING`.
+
+`signal(caseId, "humanApproval", ...)` works without an active plan item — the engine
+updates case context regardless. Confirmed by `HumanApprovalLifecycleTest` Checkpoint 5
+which signals `styleCheck`, `testCoverage`, `performanceAnalysis` (no corresponding
+WorkItems exist for those).
+
+### Why not CapturingBreachPolicy
+
+The issue describes a `CapturingBreachPolicy @Alternative @ApplicationScoped` approach.
+This approach is rejected because:
+
+1. `selected-alternatives` is build-time — `CapturingBreachPolicy` would displace
+   `SlaBreachPolicyBean` for every test in the file, making Test 1 impossible in the
+   same class.
+2. It tests `ExpiryLifecycleService → SlaBreachPolicy` dispatch — a casehub-work concern
+   already covered by `SlaBreachLifecycleTest` Checkpoints 3–4.
+3. It introduces a race condition: driving through `ExpiryLifecycleService` requires
+   `linesChanged=600 > threshold`, which fires the `human-approval` binding
+   asynchronously.
+
+### Failure modes caught
+
+| Failure | How caught |
+|---|---|
+| `SlaBreachPolicyBean` absent | Startup `UnsatisfiedResolutionException` |
+| `@ApplicationScoped` annotation missing | Startup failure |
+| `@Observes` changed to `@ObservesAsync` | Test 2 times out — event not received synchronously |
+| `@Inject PrReviewCaseHub` fails | Startup failure |
+| `switch` on `Fail` removed or wrong key | Test 2 times out — case context not updated |
+
+### Out of scope
+
+- Two-tier escalation logic → `DefaultSlaBreachPolicyTest` (domain unit test)
+- Full expiry detection chain → `SlaBreachLifecycleTest`
+- `humanApprovalThreshold` as a Preference rather than case-context field — separate issue
+  if desired; requires changes to the YAML binding and case context population
+
+---
+
+## File Location
+
+`app/src/test/java/io/casehub/devtown/app/SlaBreachHandlerWiringTest.java`
+
+No changes to `application.properties` — no new `selected-alternatives` entries.
+
+---
+
+## Protocol Compliance
+
+Follows `spi-testing-alternative-inner-classes.md` intent: test doubles are the pattern
+for SPI wiring tests. Here, no `@Alternative` is needed because we fire the CDI event
+directly rather than driving through the SPI caller. GE-20260512-c246b0 warnings about
+`selected-alternatives` pitfalls are avoided entirely.


### PR DESCRIPTION
## Summary

- Adds `SlaBreachHandlerWiringTest` — focused CDI wiring test for the SLA breach path
- Test 1: asserts `@Inject SlaBreachPolicy` resolves to `SlaBreachPolicyBean` (not `NoOpSlaBreachPolicy @DefaultBean`)
- Test 2: fires `SlaBreachEvent` directly via `Event<SlaBreachEvent>`, asserts case context updated

## Design notes

Rejects the `CapturingBreachPolicy @Alternative` approach originally specified: `selected-alternatives` is build-time and would displace `SlaBreachPolicyBean`, making the displacement check untestable in the same class. Direct event fire isolates the handler from `ExpiryLifecycleService`, which is already covered by `SlaBreachLifecycleTest`.

## Test plan

- [x] `slaBreachPolicyBean_displaces_noOp` — passes
- [x] `slaBreachHandler_onFail_signalsCaseContext` — passes
- [x] Full suite 15/15 green

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)