### PR TITLE
chore: S/XS cleanup — remove reactive workaround, add test coverage parity

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,53 @@
+#!/bin/bash
+# pre-push hook: mechanical squash candidate check
+# Installed by git-squash skill. Blocks obvious policy violations before push.
+# Run /git-squash for the full AI-assisted analysis.
+# Bypass with: git push --no-verify
+
+remote="$1"
+
+SQUASH_PATTERNS='(^chore: (remove dead|apply spotless|fix formatting|remove unused|pin |add jandex)|^docs\([^)]+\): (align|fix wording|add missing)|^docs: fix stale|^fix\(test\):|^fix\(ci\):|^ci: (retrigger|trigger CI|use GH_PAT|standardise|add workflow)|^chore: (retroactive issue|pin )|^Revert ")'
+
+total=0
+candidates=0
+revert_pairs=0
+
+while read local_ref local_sha remote_ref remote_sha; do
+  # Skip branch deletions
+  [ "$local_sha" = "0000000000000000000000000000000000000000" ] && continue
+
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    # New branch — compare to default branch
+    base=$(git rev-parse --verify origin/main 2>/dev/null || git rev-parse --verify origin/master 2>/dev/null || echo "")
+    [ -z "$base" ] && continue
+    range="$base..$local_sha"
+  else
+    range="$remote_sha..$local_sha"
+  fi
+
+  total=$(git log --oneline "$range" 2>/dev/null | wc -l | tr -d ' ')
+  [ "$total" -eq 0 ] && continue
+
+  candidates=$(git log --oneline "$range" 2>/dev/null | grep -cE "$SQUASH_PATTERNS" || true)
+
+  # Check for small commits (≤ 4 lines changed, no issue ref) — harder to do in hook,
+  # approximated by looking for fixup-style prefixes not caught above
+  small=$(git log --oneline "$range" 2>/dev/null | grep -cE "^[a-f0-9]+ (fix|chore|style|docs)\([^)]+\): .{1,30}$" | grep -v "#" || true)
+
+  if [ "$candidates" -gt 0 ]; then
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════╗"
+    echo "║  Squash policy check — candidates found                  ║"
+    echo "╠══════════════════════════════════════════════════════════╣"
+    echo "║  Commits in push:    $total"
+    echo "║  Squash candidates:  $candidates"
+    echo "║"
+    echo "║  Run /git-squash to review and clean history before      ║"
+    echo "║  pushing, or use --no-verify to skip this check.         ║"
+    echo "╚══════════════════════════════════════════════════════════╝"
+    echo ""
+    exit 1
+  fi
+done
+
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,9 @@ jobs:
           distribution: 'temurin'
           server-id: github
           server-username: GITHUB_ACTOR
-          server-password: GH_PAT
+          server-password: GITHUB_TOKEN
 
       - name: Build and test
         run: mvn --batch-mode verify
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,10 @@ jobs:
           distribution: 'temurin'
           server-id: github
           server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
+          server-password: GH_PAT
 
       - name: Build and test
         run: mvn --batch-mode verify
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,9 @@ jobs:
           distribution: 'temurin'
           server-id: github
           server-username: GITHUB_ACTOR
-          server-password: GH_PAT
+          server-password: GITHUB_TOKEN
 
       - name: Publish to GitHub Packages
         run: mvn --batch-mode deploy -DskipTests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,10 @@ jobs:
           distribution: 'temurin'
           server-id: github
           server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
+          server-password: GH_PAT
 
       - name: Publish to GitHub Packages
         run: mvn --batch-mode deploy -DskipTests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,11 +277,23 @@ JAVA_HOME=/Library/Java/JavaVirtualMachines/graalvm-25.jdk/Contents/Home  # Graa
 ---
 
 
+## Design Document Convention
+
+The design doc for this project is `design/JOURNAL.md`, created by `epic` when an
+epic opens. Between epics this file does not exist.
+
+When `java-git-commit` or `java-update-design` check for DESIGN.md: if no epic is
+active (i.e. `design/JOURNAL.md` does not exist), skip the design sync step entirely.
+Do not stop or error — just omit it and proceed.
+
 ## Development Workflow
 
+Session start: `work-start` (platform coherence, protocols, issue check, IntelliJ MCPs)
 Before designing: `superpowers:brainstorming`
 Before implementing: `superpowers:test-driven-development`
+For all Java work: `java-dev` (loads `testing-principles` + `ide-tooling`)
 Before committing: `superpowers:requesting-code-review`
+After implementation: `implementation-doc-sync` (scoped doc sweep)
 
 Living docs — check for drift after significant changes:
 - `docs/adr/INDEX.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,11 +104,9 @@ type: java
 
 **Secondary goal:** LLM and human tutorial material, produced as a by-product of building the application correctly. The tutorial structure emerges from the layered adoption sequence — do not design for the tutorial.
 
-**LAYER-LOG.md** (`LAYER-LOG.md` at project root) is the primary new artifact. A layer is not complete until its entry is fully written — but entries are written incrementally across sessions. Write what is known now; mark pending sections with `🔲` including expected content so future sessions can fill them in without context reconstruction.
+**LAYER-LOG.md** (`LAYER-LOG.md` at project root) is the primary new artifact. A layer entry is complete when the layer closes — written in full at that point, not incrementally with placeholders.
 
 **Epics ≠ layers.** Epics organize work by build convenience; layers organize knowledge by teaching progression. One layer may span multiple epics. The layer table in `../parent/docs/repos/casehub-devtown.md` tracks layer status (pending / in progress / complete) — update it when a layer makes meaningful progress, not only when it finishes.
-
-See `docs/protocols/universal/layer-log.md` in casehub-parent for the full format and placeholder guidance.
 
 ---
 
@@ -148,8 +146,8 @@ Never add to the foundation what is specific to this domain. Never re-implement 
 | `../parent/docs/AGENTIC-HARNESS-GUIDE.md` | Goals, what to produce, retroactive work instructions, layer maintenance |
 | `../parent/docs/repos/casehub-devtown.md` | Harness structure, tutorial layers table, layer status |
 | `../parent/docs/tutorial-strategy.md` | Devtown tutorial layers §7.5 — teaching objectives and code sketches per layer |
-| `../parent/docs/protocols/casehub/HARNESS-INDEX.md` | CaseHub app protocols |
-| `../parent/docs/protocols/universal/INDEX.md` | Universal Java/Quarkus protocols |
+| `../garden/docs/protocols/casehub/HARNESS-INDEX.md` | CaseHub app protocols |
+| `../garden/docs/protocols/universal/INDEX.md` | Universal Java/Quarkus protocols |
 
 ## Reference Documents (this repo)
 
@@ -160,6 +158,56 @@ These live in `docs/` in this repo and should be read before any significant imp
 | `docs/gastown-casehub-analysis-v2.md` | Full architectural comparison — foundation vs foundation, application vs application, roadmap, 32-finding coherence audit, phase gates |
 | `docs/gastown-casehub-analysis.md` | Earlier version — useful for background and alternative framing |
 | `docs/orchestration-advantages.md` | Seven concrete ACM advantages over workflow engines for PR review scenarios — with YAML examples |
+
+---
+
+## Design Phase References
+
+Read these **before designing**, not after. The concern column tells you when each applies.
+
+### Domain model and API design
+
+| Concern | Read first |
+|---------|-----------|
+| Designing a new entity, record, or SPI | `casehub-devtown.md` — does devtown already own this? `PLATFORM.md` capability ownership table — does the foundation own it? |
+| Module placement (`domain/` vs `review/` vs `app/`) | Three-tier rule: `devtown-domain` = pure Java (no Quarkus), `review` = integration logic (casehub-work/engine deps), `app` = all CDI wiring. Port interface (`PrReviewApplicationService`) lives in `review/`, not `app/` — prevents a module dependency cycle |
+| Naming capability tags or trust dimensions | `ReviewDomain`, `AgentQualification`, `HumanDecision`, `HumanOversight`, `DevtownTrustDimension` in `devtown-domain` — extend these rather than creating parallel types |
+| Mapping features to Gastown parity | `docs/gastown-casehub-analysis-v2.md` Gastown feature parity checklist — which Gastown capability does this correspond to, and does devtown's approach improve on it? |
+
+### Tutorial layer design
+
+| Concern | Read first |
+|---------|-----------|
+| Deciding which layer a feature belongs in | `tutorial-strategy.md §7.5` — layer teaching objectives and what each layer must NOT include |
+| Understanding the `@DefaultBean` displacement pattern | LAYER-LOG.md Layer 1 §Key wiring — `NaivePrReviewService @DefaultBean` is displaced at CDI level by each subsequent layer; the naive class is never deleted |
+| Writing gap comments | `NaivePrReviewService.java` — five gap comments model the Layer 1 anti-pattern; each subsequent layer closes exactly one gap |
+| Documenting a completed layer | LAYER-LOG.md — write the entry in full when the layer closes; no incremental placeholders |
+
+### Foundation integration
+
+| Concern | Read first |
+|---------|-----------|
+| Using casehub-work (WorkItem, SLA, escalation) | `../parent/docs/repos/casehub-work.md` |
+| Using casehub-qhorus (COMMAND/RESPONSE/DONE/DECLINE) | `../parent/docs/repos/casehub-qhorus.md` |
+| Using casehub-ledger (Merkle audit, GDPR, trust scoring) | `../parent/docs/repos/casehub-ledger.md` |
+| Using casehub-engine (CasePlanModel, adaptive paths, bindings) | `../parent/docs/repos/casehub-engine.md` |
+| Boundary check — foundation or devtown? | `PLATFORM.md` boundary rules; Layering Rule in this file — if it requires knowledge of PRs, code review, CI, or merge queues, it belongs here |
+
+### Persistence and migrations
+
+| Concern | Read first |
+|---------|-----------|
+| Writing a new Flyway migration | `../garden/docs/protocols/universal/flyway-migration-rules.md` — naming, H2 MODE=PostgreSQL |
+| Assigning a migration version number | V1–V999 devtown domain; V2000+ ledger subclass join tables |
+| Adding casehub-work JPA persistence | devtown#34 — `casehub-persistence-hibernate` must be in the production assembly; without it, engine CDI SPIs are unsatisfied at augmentation |
+
+### Testing
+
+| Concern | Read first |
+|---------|-----------|
+| Writing a `@QuarkusTest` for HITL bindings | PP-20260521-134c38 (pre-seed all parallel check keys with non-null values); PP-20260521-a36692 (MemoryPlanItemStore in `quarkus.arc.selected-alternatives`) |
+| Testing SPI wiring | `../garden/docs/protocols/universal/spi-testing-alternative-inner-classes.md` — `@Alternative` static inner classes, not Mockito |
+| `@QuarkusTest` database setup | `../garden/docs/protocols/universal/quarkus-test-database.md` — H2 MODE=PostgreSQL, datasource config |
 
 ---
 
@@ -226,8 +274,8 @@ These live in `docs/` in this repo and should be read before any significant imp
 | Content-driven routing | P0 complete (engine#186 merged) ✅ DONE |
 | Parallel check execution | P0 complete ✅ DONE |
 | PR review CasePlanModel (Epic 3) | P0 complete ✅ DONE — devtown#10 shipped 2026-05-19 |
-| Scoped policy preferences | casehub-platform-api (parent#26) — stub via @ConfigProperty until SPI lands |
-| Human review WorkItem end-to-end | P0 complete ✅ DONE — casehub-work-adapter wired (devtown#33), e2e test pending (devtown#30) |
+| Scoped policy preferences | casehub-platform ✅ shipped — `PreferenceProvider` with `Path`-based scope hierarchy and JPA persistence available |
+| Human review WorkItem end-to-end | P0 complete ✅ DONE — casehub-work-adapter wired (devtown#33), e2e test complete (devtown#30 ✅ 2026-05-21) |
 | Trust-weighted assignment | P1 complete (P1.3 — TrustWeightedSelectionStrategy wired) |
 | Merge queue (full) | P1 complete |
 | Cryptographic audit | P1.4 ✅ DONE (CaseLedgerEntry merged 2026-04-26) |
@@ -243,6 +291,22 @@ These live in `docs/` in this repo and should be read before any significant imp
 - P1.4 CaseLedgerEntry ✅ DONE — merged 2026-04-26
 - **Remaining P0:** qhorus#124 claudony persona→session mapping (no end-to-end trust accumulation yet)
 - **Remaining P1:** concurrency throttling (P1.1), RecoveryPolicy SPI (P1.2), TrustWeightedSelectionStrategy wired (P1.3), Doltgres backend (P1.5)
+
+### Tutorial Structure (layer-by-layer, from tutorial-strategy.md §7.5)
+
+```
+Layer 1: naive Java — vocabulary model, @DefaultBean naive service, REST entry point ✅ (devtown#8, #9, #27)
+Layer 2: + casehub-work — SLA-bounded human review gate with escalation (devtown#38, in progress)
+Layer 3: + casehub-qhorus — typed COMMAND/RESPONSE/DONE/DECLINE per reviewer agent interaction
+Layer 4: + casehub-ledger — tamper-evident merge decision audit trail
+Layer 5: + casehub-engine — adaptive paths, CasePlanModel, content-driven PR routing ✅ (devtown#10)
+Layer 6: trust routing — trust-weighted reviewer assignment from outcome attestations
+Layer 7: comparison vs Gastown (Refinery/Deacon/Witness architecture)
+```
+
+**Note on layer ordering vs build order:** Layer 5 was built before Layers 2–4 because the engine CasePlanModel (adaptive routing, HITL binding) was the architectural priority. Tutorial ordering differs from chronological build order — LAYER-LOG.md preserves teaching sequence, not build sequence.
+
+**`@DefaultBean` displacement pattern:** devtown uses CDI displacement throughout. `NaivePrReviewService @DefaultBean` is never deleted — each layer adds an `@ApplicationScoped` implementation (without `@DefaultBean`) in `review/` that takes CDI priority. The naive class remains in the build, inactive. This is the structural mechanism that makes each layer independently teachable.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ These live in `docs/` in this repo and should be read before any significant imp
 | Parallel check execution | P0 complete ✅ DONE |
 | PR review CasePlanModel (Epic 3) | P0 complete ✅ DONE — devtown#10 shipped 2026-05-19 |
 | Scoped policy preferences | casehub-platform-api (parent#26) — stub via @ConfigProperty until SPI lands |
-| Human review WorkItem end-to-end | P0 complete, casehub-work-adapter HITL wiring (devtown#30) |
+| Human review WorkItem end-to-end | P0 complete ✅ DONE — casehub-work-adapter wired (devtown#33), e2e test pending (devtown#30) |
 | Trust-weighted assignment | P1 complete (P1.3 — TrustWeightedSelectionStrategy wired) |
 | Merge queue (full) | P1 complete |
 | Cryptographic audit | P1.4 ✅ DONE (CaseLedgerEntry merged 2026-04-26) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,17 +223,19 @@ These live in `docs/` in this repo and should be read before any significant imp
 
 | Capability | Foundation prerequisite |
 |-----------|------------------------|
-| Content-driven routing | P0 complete (engine#186 merged) |
-| Parallel check execution | P0 complete |
+| Content-driven routing | P0 complete (engine#186 merged) ✅ DONE |
+| Parallel check execution | P0 complete ✅ DONE |
+| PR review CasePlanModel (Epic 3) | P0 complete ✅ DONE — devtown#10 shipped 2026-05-19 |
+| Scoped policy preferences | casehub-platform-api (parent#26) — stub via @ConfigProperty until SPI lands |
+| Human review WorkItem end-to-end | P0 complete, casehub-work-adapter HITL wiring (devtown#30) |
 | Trust-weighted assignment | P1 complete (P1.3 — TrustWeightedSelectionStrategy wired) |
-| Human review WorkItem | P0 complete, casehub-work-adapter HITL wiring |
 | Merge queue (full) | P1 complete |
 | Cryptographic audit | P1.4 ✅ DONE (CaseLedgerEntry merged 2026-04-26) |
 | Failure routing (DECLINED vs FAILED) | P0 complete (qhorus#124 claudony persona mapping) |
 | Recovery on stuck reviewer | P1.2 RecoveryPolicy SPI |
 | Cross-deployment trust | P2.1 TrustExport/ImportService |
 
-**Current foundation status (as of 2026-05-11):**
+**Current foundation status (as of 2026-05-19):**
 - P0.1 engine-side ✅ DONE — engine#186 closed
 - P0.2 ✅ DONE — qhorus#123, commitment outcomes → trust scoring
 - P0.3 ActorTypeResolver ✅ DONE — all consumers updated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,7 @@ Read these **before designing**, not after. The concern column tells you when ea
 | Content-driven routing | P0 complete (engine#186 merged) ✅ DONE |
 | Parallel check execution | P0 complete ✅ DONE |
 | PR review CasePlanModel (Epic 3) | P0 complete ✅ DONE — devtown#10 shipped 2026-05-19 |
-| Scoped policy preferences | casehub-platform ✅ shipped — `PreferenceProvider` with `Path`-based scope hierarchy and JPA persistence; `Path.root()` pending platform publish (blocks work#212, GE-20260522-9cd6d5) |
+| Scoped policy preferences | casehub-platform ✅ shipped — `PreferenceProvider` with `Path`-based scope hierarchy and JPA persistence; `Path.root()` ✅ DONE (platform#24 closed, work#212 closed 2026-05-22) |
 | Human review WorkItem end-to-end | P0 complete ✅ DONE — casehub-work-adapter wired (devtown#33), e2e test complete (devtown#30 ✅ 2026-05-21) |
 | Trust-weighted assignment | P1 complete (P1.3 — TrustWeightedSelectionStrategy wired) |
 | Merge queue (full) | P1 complete |
@@ -297,7 +297,7 @@ Read these **before designing**, not after. The concern column tells you when ea
 
 ```
 Layer 1: naive Java — vocabulary model, @DefaultBean naive service, REST entry point ✅ (devtown#8, #9, #27)
-Layer 2: + casehub-work — SLA-bounded human review gate with escalation (devtown#38, in progress)
+Layer 2: + casehub-work — SLA-bounded human review gate with escalation (devtown#41, in progress)
 Layer 3: + casehub-qhorus — typed COMMAND/RESPONSE/DONE/DECLINE per reviewer agent interaction
 Layer 4: + casehub-ledger — tamper-evident merge decision audit trail
 Layer 5: + casehub-engine — adaptive paths, CasePlanModel, content-driven PR routing ✅ (devtown#10)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,7 @@ Read these **before designing**, not after. The concern column tells you when ea
 | Using casehub-ledger (Merkle audit, GDPR, trust scoring) | `../parent/docs/repos/casehub-ledger.md` |
 | Using casehub-engine (CasePlanModel, adaptive paths, bindings) | `../parent/docs/repos/casehub-engine.md` |
 | Boundary check — foundation or devtown? | `PLATFORM.md` boundary rules; Layering Rule in this file — if it requires knowledge of PRs, code review, CI, or merge queues, it belongs here |
+| Implementing a `@Transactional` loop with control-flow exceptions | PP-20260522-f08b62 — private exceptions must not escape the loop boundary; validate eagerly at factory and catch at top-level dispatch |
 
 ### Persistence and migrations
 
@@ -274,7 +275,7 @@ Read these **before designing**, not after. The concern column tells you when ea
 | Content-driven routing | P0 complete (engine#186 merged) ✅ DONE |
 | Parallel check execution | P0 complete ✅ DONE |
 | PR review CasePlanModel (Epic 3) | P0 complete ✅ DONE — devtown#10 shipped 2026-05-19 |
-| Scoped policy preferences | casehub-platform ✅ shipped — `PreferenceProvider` with `Path`-based scope hierarchy and JPA persistence available |
+| Scoped policy preferences | casehub-platform ✅ shipped — `PreferenceProvider` with `Path`-based scope hierarchy and JPA persistence; `Path.root()` pending platform publish (blocks work#212, GE-20260522-9cd6d5) |
 | Human review WorkItem end-to-end | P0 complete ✅ DONE — casehub-work-adapter wired (devtown#33), e2e test complete (devtown#30 ✅ 2026-05-21) |
 | Trust-weighted assignment | P1 complete (P1.3 — TrustWeightedSelectionStrategy wired) |
 | Merge queue (full) | P1 complete |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,22 +68,22 @@ Before any git operation, run `git rev-parse --show-toplevel` to confirm which r
 
 This repo is one component of the casehubio multi-repo platform. **Before implementing anything — any feature, SPI, data model, or abstraction — run the Platform Coherence Protocol.**
 
-> **Platform docs:** Local paths use `~/claude/casehub/parent/docs/` as root. If a path doesn't exist, the parent repo isn't cloned locally — fetch from `https://raw.githubusercontent.com/casehubio/parent/main/docs/<path>` instead.
+> **Platform docs:** Local paths use `../parent/docs/` as root. If a path doesn't exist, the parent repo isn't cloned locally — fetch from `https://raw.githubusercontent.com/casehubio/parent/main/docs/<path>` instead.
 
 The protocol asks: Does this already exist elsewhere? Is this the right repo for it? Does this create a consolidation opportunity? Is this consistent with how the platform handles the same concern in other repos?
 
 **Platform architecture (fetch before any implementation decision):**
 ```
-~/claude/casehub/parent/docs/PLATFORM.md
+../parent/docs/PLATFORM.md
 ```
 
 **Foundation repo deep-dives** (fetch the relevant ones when your implementation touches their domain):
-- casehub-engine: `~/claude/casehub/parent/docs/repos/casehub-engine.md`
-- casehub-ledger: `~/claude/casehub/parent/docs/repos/casehub-ledger.md`
-- casehub-work: `~/claude/casehub/parent/docs/repos/casehub-work.md`
-- casehub-qhorus: `~/claude/casehub/parent/docs/repos/casehub-qhorus.md`
-- casehub-connectors: `~/claude/casehub/parent/docs/repos/casehub-connectors.md`
-- claudony: `~/claude/casehub/parent/docs/repos/claudony.md`
+- casehub-engine: `../parent/docs/repos/casehub-engine.md`
+- casehub-ledger: `../parent/docs/repos/casehub-ledger.md`
+- casehub-work: `../parent/docs/repos/casehub-work.md`
+- casehub-qhorus: `../parent/docs/repos/casehub-qhorus.md`
+- casehub-connectors: `../parent/docs/repos/casehub-connectors.md`
+- claudony: `../parent/docs/repos/claudony.md`
 
 ---
 
@@ -95,9 +95,23 @@ type: java
 
 ---
 
+## Agentic Harness Goals
+
+**Read first:** `../parent/docs/AGENTIC-HARNESS-GUIDE.md`
+
+**Primary goal:** Reference architecture and field showcase for Java developers in software engineering and DevOps — demonstrating formal accountability, tamper-evident review records, and adaptive routing in a domain every developer knows from daily practice.
+
+**Secondary goal:** LLM and human tutorial material, produced as a by-product of building the application correctly. The tutorial structure emerges from the layered adoption sequence — do not design for the tutorial.
+
+**LAYER-LOG.md** (`LAYER-LOG.md` at project root) is the primary new artifact. A layer is not complete until its entry is written. See the AML reference implementation and `docs/protocols/universal/layer-log.md` in casehub-parent for the format.
+
+---
+
 ## What This Project Is
 
-`casehub-devtown` is the **AI-assisted software development application** built on the CaseHub platform foundation. It is the CaseHub answer to Gastown — a production software engineering coordination system — but built on a domain-agnostic foundation rather than baked into infrastructure.
+`casehub-devtown` is an **agentic harness for software engineering coordination** built on the CaseHub platform foundation. It coordinates specialist code reviewers, human review task gates with SLA, and adaptive PR routing based on code content — producing a tamper-evident review record where every missed finding is traceable. Field showcase and tutorial for Java developers in software engineering and DevOps.
+
+It is the CaseHub answer to Gastown — a production software engineering coordination system — but built on a domain-agnostic foundation rather than baked into infrastructure.
 
 The foundation (casehub-engine, casehub-qhorus, casehub-ledger, casehub-work, casehub-connectors) has **no domain knowledge**. It knows about cases, bindings, workers, commitments, trust, and audit. devtown provides the software engineering domain logic on top of those primitives: what a PR review is, what a merge queue does, what capabilities are required for what work, how trust accumulates from review outcomes.
 
@@ -122,7 +136,17 @@ Never add to the foundation what is specific to this domain. Never re-implement 
 
 ---
 
-## Reference Documents
+## Reference Documents (casehub-parent)
+
+| Document | What it covers |
+|----------|---------------|
+| `../parent/docs/AGENTIC-HARNESS-GUIDE.md` | Goals, what to produce, retroactive work instructions, layer maintenance |
+| `../parent/docs/repos/casehub-devtown.md` | Harness structure, tutorial layers table, layer status |
+| `../parent/docs/tutorial-strategy.md` | Devtown tutorial layers §7.5 — teaching objectives and code sketches per layer |
+| `../parent/docs/protocols/casehub/HARNESS-INDEX.md` | CaseHub app protocols |
+| `../parent/docs/protocols/universal/INDEX.md` | Universal Java/Quarkus protocols |
+
+## Reference Documents (this repo)
 
 These live in `docs/` in this repo and should be read before any significant implementation:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,13 +200,14 @@ Read these **before designing**, not after. The concern column tells you when ea
 |---------|-----------|
 | Writing a new Flyway migration | `../garden/docs/protocols/universal/flyway-migration-rules.md` — naming, H2 MODE=PostgreSQL |
 | Assigning a migration version number | V1–V999 devtown domain; V2000+ ledger subclass join tables |
-| Adding casehub-work JPA persistence | devtown#34 — `casehub-persistence-hibernate` must be in the production assembly; without it, engine CDI SPIs are unsatisfied at augmentation |
+| Engine persistence SPIs (EventLogRepository, CaseInstanceRepository, etc.) | Satisfied by `@ApplicationScoped` subclasses in `app/src/main/java/io/casehub/devtown/app/spi/` (devtown#40 ✅ 2026-05-24). Do not use `quarkus.arc.selected-alternatives` — it does not activate beans during `quarkus:build`. |
+| Adding casehub-work JPA persistence | devtown#34 still open — `casehub-persistence-hibernate` for production PostgreSQL backend |
 
 ### Testing
 
 | Concern | Read first |
 |---------|-----------|
-| Writing a `@QuarkusTest` for HITL bindings | PP-20260521-134c38 (pre-seed all parallel check keys with non-null values); PP-20260521-a36692 (MemoryPlanItemStore in `quarkus.arc.selected-alternatives`) |
+| Writing a `@QuarkusTest` for HITL bindings | PP-20260521-134c38 (pre-seed all parallel check keys with non-null values); only `MemoryPlanItemStore` remains in `quarkus.arc.selected-alternatives` — `MemorySubCaseGroupRepository` replaced by `DevtownSubCaseGroupRepository @ApplicationScoped` in `app/spi/` |
 | Testing SPI wiring | `../garden/docs/protocols/universal/spi-testing-alternative-inner-classes.md` — `@Alternative` static inner classes, not Mockito |
 | `@QuarkusTest` database setup | `../garden/docs/protocols/universal/quarkus-test-database.md` — H2 MODE=PostgreSQL, datasource config |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,17 @@ Run `add-dir /Users/mdproctor/claude/casehub/devtown` before any other work.
 - `blog/` — project diary entries with INDEX.md
 - `design/` — epic journal (created by `epic` at branch start)
 
+## Git Discipline
+
+Two git repositories are active in every session:
+- **Workspace** (`/Users/mdproctor/claude/public/casehub/devtown`) — methodology artifacts: handover, blog, specs, plans, ADRs
+- **Project repo** (`/Users/mdproctor/claude/casehub/devtown`) — source code
+
+Before any git operation, run `git rev-parse --show-toplevel` to confirm which repo is currently active. Do not assume — the session may have opened in either. cd to the correct repo before staging:
+- Source code commits → project repo
+- Methodology artifacts → workspace
+
+
 ## Rules
 
 - All methodology artifacts go here, not in the project repo
@@ -42,11 +53,11 @@ Run `add-dir /Users/mdproctor/claude/casehub/devtown` before any other work.
 
 | Artifact   | Destination | Notes |
 |------------|-------------|-------|
-| adr        | workspace   | |
-| blog       | workspace   | |
-| design     | workspace   | |
+| adr        | project     | lands in `docs/adr/` |
+| blog       | project     | published externally via publish-blog (blog-routing.yaml) |
+| design     | workspace   | merged into DESIGN.md at epic close |
 | snapshots  | workspace   | |
-| specs      | workspace   | |
+| specs      | project     | lands in `docs/specs/` |
 | handover   | workspace   | |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,12 @@ Before any git operation, run `git rev-parse --show-toplevel` to confirm which r
 
 | Artifact   | Destination | Notes |
 |------------|-------------|-------|
-| adr        | project     | lands in `docs/adr/` |
-| blog       | project     | published externally via publish-blog (blog-routing.yaml) |
-| design     | workspace   | merged into DESIGN.md at epic close |
-| snapshots  | workspace   | |
-| specs      | project     | lands in `docs/specs/` |
+| adr        | project     | lands in `docs/adr/` — promoted at epic close |
+| specs      | project     | lands in `docs/specs/` — promoted at epic close |
+| blog       | workspace   | staged here; published to mdproctor.github.io via publish-blog |
+| plans      | workspace   | stay in workspace permanently |
+| design     | workspace   | epic journal stays in workspace |
+| snapshots  | workspace   | stay in workspace permanently |
 | handover   | workspace   | |
 
 ---
@@ -103,7 +104,11 @@ type: java
 
 **Secondary goal:** LLM and human tutorial material, produced as a by-product of building the application correctly. The tutorial structure emerges from the layered adoption sequence — do not design for the tutorial.
 
-**LAYER-LOG.md** (`LAYER-LOG.md` at project root) is the primary new artifact. A layer is not complete until its entry is written. See the AML reference implementation and `docs/protocols/universal/layer-log.md` in casehub-parent for the format.
+**LAYER-LOG.md** (`LAYER-LOG.md` at project root) is the primary new artifact. A layer is not complete until its entry is fully written — but entries are written incrementally across sessions. Write what is known now; mark pending sections with `🔲` including expected content so future sessions can fill them in without context reconstruction.
+
+**Epics ≠ layers.** Epics organize work by build convenience; layers organize knowledge by teaching progression. One layer may span multiple epics. The layer table in `../parent/docs/repos/casehub-devtown.md` tracks layer status (pending / in progress / complete) — update it when a layer makes meaningful progress, not only when it finishes.
+
+See `docs/protocols/universal/layer-log.md` in casehub-parent for the full format and placeholder guidance.
 
 ---
 

--- a/LAYER-LOG.md
+++ b/LAYER-LOG.md
@@ -1,8 +1,8 @@
 # devtown Agentic Harness — Layer Log
 
-Structured record of what was built at each layer, optimised for LLM consumption and future tutorial generation. Correlates with blog entries in `blog/`, git history, and GitHub issues.
+Structured record of what was built at each layer, optimised for LLM consumption. Each entry is the raw material needed to reproduce the layer in a different domain harness. Correlates with blog entries in `blog/`, git history, and GitHub issues.
 
-Each entry documents one layer of the adoption sequence. Entries are written when work on that layer begins — not before. Sections marked `🔲` within an entry are placeholders: the work for that section isn't done yet, but the expected content or pointer is included so future sessions can fill it in without reconstructing context.
+Entries are ordered for learning, not chronology. Each entry is complete when the layer closes — no placeholders.
 
 Cross-references:
 - Blog entries: workspace `blog/` (staged; published to mdproctor.github.io/_notes/ via `publish-blog`)
@@ -210,8 +210,8 @@ Layer 5 closes: attribution (`CaseLedgerEntry` records which binding dispatched 
   - Cause: engine CDI SPIs are unsatisfied without claudony + persistence module present. This is a known foundation gap — the harness app cannot be packaged standalone without its full dependency stack.
   - Status: tracked in devtown#31. Does not affect test coverage or local development.
 
-- **HITL wiring gap (known, deferred)**
-  - `HumanTaskTarget` bindings in the YAML compile and unit-test correctly, but the casehub-work-adapter does not yet bridge `WorkItemLifecycleEvent → PlanItem` transitions for devtown. Full human approval flow is deferred to devtown#30. Tests use mock workers.
+- **HITL wiring gap (resolved devtown#30, 2026-05-21)**
+  - `HumanTaskTarget` bindings were initially unit-tested only. The full `WorkItemLifecycleEvent → PlanItem` bridge was completed in devtown#30: `HumanApprovalLifecycleTest` verifies the end-to-end lifecycle including `@ObservesAsync` delivery and `outputMapping` → case context update.
 
 ### Pattern to replicate (in another domain)
 

--- a/LAYER-LOG.md
+++ b/LAYER-LOG.md
@@ -141,16 +141,21 @@ These were in the original Gastown-derived 13-tag vocabulary and removed. They a
 
 ## Layer 5 — casehub-engine (adaptive routing on code content)
 
-**Completed:** 🔲 in progress — Epic 3 (devtown#10) started 2026-05-15, brainstorming in progress
+**Completed:** Epic 3 (devtown#10) shipped 2026-05-19
 **Issues:** casehubio/devtown#10 (Epic 3: PR review CasePlanModel — content-driven routing and parallel checks)
-**Design specs:** 🔲 to be written — will land in `docs/specs/` when brainstorming completes this session
-**Blog:** 🔲
-**Improvement log:** 🔲 — DT entries to be added as implementation decisions are made
+**Design specs:** `docs/specs/2026-05-15-epic3-pr-review-caseplanmodel-design.md`
+**Blog:** `blog/2026-05-19-mdp01-from-naive-to-adaptive.md` 🔲 (not yet drafted)
+**Improvement log:** `docs/PROGRESS.md` — DT entries to be added as improvement decisions are formalised
 
 **Key files:**
-- 🔲 `review/src/main/resources/devtown/pr-review.yaml` — YAML CasePlanModel definition; expected when Epic 3 ships. See §What it shows.
-- 🔲 `review/src/main/java/io/casehub/devtown/review/PrReviewCaseService.java` — expected: `@ApplicationScoped` (no `@DefaultBean`); displaces `NaivePrReviewService`. See §Key wiring.
-- 🔲 `review/src/test/java/io/casehub/devtown/review/PrReviewBindingConditionTest.java` — expected: plain unit tests for JQ binding `when` conditions using `LambdaExpressionEvaluator`
+- `review/src/main/resources/devtown/pr-review.yaml` — YAML CasePlanModel: 9 bindings (4 groups), 3 goals, 9 capabilities
+- `app/src/main/java/io/casehub/devtown/app/PrReviewCaseHub.java` — `@ApplicationScoped extends YamlCaseHub("devtown/pr-review.yaml")`
+- `app/src/main/java/io/casehub/devtown/app/PrReviewCaseService.java` — `@ApplicationScoped implements PrReviewApplicationService` (no `@DefaultBean`); displaces `NaivePrReviewService`
+- `review/src/test/java/io/casehub/devtown/review/PrReviewCaseDefinition.java` — fluent DSL factory for binding condition unit tests
+- `review/src/test/java/io/casehub/devtown/review/MapCaseContext.java` — `CaseContext` test helper backed by `Map<String,Object>`
+- `review/src/test/java/io/casehub/devtown/review/PrReviewBindingConditionTest.java` — 28 pure unit tests for all 9 binding conditions; no Quarkus required
+- `app/src/test/java/io/casehub/devtown/app/PrReviewCaseHubTest.java` — `@QuarkusTest` YAML round-trip: 5 tests verifying binding/goal/capability counts
+- `app/src/test/java/io/casehub/devtown/app/InMemoryLedgerEntryRepository.java` — `@ApplicationScoped` test stub; needed for `@QuarkusTest` CDI resolution when `casehub-ledger` runtime is on the classpath
 
 ### What it shows
 
@@ -162,7 +167,7 @@ See `docs/orchestration-advantages.md` §1 (content-driven routing), §2 (parall
 
 ### The gap comments
 
-🔲 To fill when Layer 5 code ships. These are the Layer 1 gap comments that Layer 5 addresses:
+These are the Layer 1 gap comments that Layer 5 addresses:
 
 ```java
 // LAYER 1 GAP: no attribution — which agent ran this analysis? No record.
@@ -176,31 +181,46 @@ Layer 5 closes: attribution (`CaseLedgerEntry` records which binding dispatched 
 
 ### Key wiring
 
-🔲 To fill as Epic 3 implementation decisions are made. Expected areas:
+1. **YAML lives in `review/`, wired in `app/`.** `pr-review.yaml` lives in `review/src/main/resources/devtown/` — Quarkus classloader picks it up from the review module JAR at test time; no copy to `app/` needed. `PrReviewCaseHub` and `PrReviewCaseService` live in `app/` — consistent with platform convention: all CDI wiring in the Tier 3 app module.
 
-- **YAML loading at startup** — classpath resource loader pattern; check engine test `YamlSimpleCaseHubBeanTest` for how `CaseDefinition` is loaded from YAML and registered as a `CaseMetaModel`
-- **`@DefaultBean` displacement** — `PrReviewCaseService @ApplicationScoped` (no `@DefaultBean`) in `review` displaces `NaivePrReviewService @DefaultBean` in `app`. Same CDI pattern as Layer 1 established; no extra wiring needed
-- **`HumanTaskTarget` binding** — use `HumanTaskTarget.inline()` (not template — casehub-work templates not yet configured in devtown). API: `io.casehub.api.model.HumanTaskTarget`
-- **Binding `when` conditions** — JQ expressions over `CaseContext`; need a committed CaseContext schema defining PR payload fields and code-analysis output fields. Schema design is the first open question in Epic 3 brainstorming (in progress)
-- **`@DefaultBean` on engine no-op SPIs** — any new SPI no-ops must use `@DefaultBean @ApplicationScoped`, not bare `@ApplicationScoped`; see `parent/docs/protocols/engine-spi-noops-defaultbean.md`
+2. **`@DefaultBean` displacement.** `PrReviewCaseService @ApplicationScoped` (no `@DefaultBean`) displaces `NaivePrReviewService @DefaultBean` — no explicit CDI configuration required. Both classes remain in the build; Layer 1 is never deleted.
+
+3. **Initial CaseContext.** `PrReviewCaseService.review(PrPayload)` builds `{ pr: {...}, policy: {...} }` from the payload and `@ConfigProperty`-injected policy values. The `policy` subtree will be replaced by `PreferenceProvider.resolve(scope).asMap()` when casehub-platform-api ships (parent#26).
+
+4. **`casehub-engine` runtime in `app/pom.xml`.** Required for `YamlCaseHub` CDI injection of `CaseHubRuntime`. Without it, Quarkus fails to satisfy the injection point at startup.
+
+5. **Human approval via capability string.** Expressed as `capability: human-decision:pr-approval` in YAML. Full `HumanTaskTarget` wiring (casehub-work-adapter bridging `WorkItemLifecycleEvent → PlanItem`) is deferred to devtown#30.
+
+6. **`casehub-engine` and `casehub-engine-testing` (test scope) added to `app/pom.xml`.** `casehub-engine-testing` provides engine test repos; `casehub-ledger` test repos are not included — see §Gotchas.
 
 ### Gotchas
 
-🔲 To fill as encountered during Epic 3 implementation. Known risks:
+- **`@QuarkusTest` CDI failure with `casehub-ledger` runtime on classpath — misleading error message**
+  - Symptom: `@QuarkusTest` fails with `ClassSelector resolution failed` — looks like a class-loading or missing dependency problem, not a CDI error
+  - Cause: `casehub-ledger` provides a Panache `ReactiveLedgerEntryRepository` requiring a real datasource. `casehub-engine-testing` provides engine repos but not ledger repos. CDI cannot satisfy the injection point, but the error message does not name the unsatisfied bean.
+  - Fix: add `@ApplicationScoped InMemoryLedgerEntryRepository` stub to `{domain}-app/src/test/`. Tracked in garden as GE-20260519-e13b01.
 
-- **`@ApplicationScoped` no-op SPI in engine without `@DefaultBean`** — collides with devtown's implementation when indexed together via `casehub-testing`. Symptom: CDI ambiguity error on `@QuarkusTest`. Fix: `@DefaultBean @ApplicationScoped` on all engine no-ops. Protocol: `parent/docs/protocols/engine-spi-noops-defaultbean.md`
-- **HITL wiring gap** — `HumanTaskTarget` bindings in the YAML compile but the casehub-work-adapter does not yet bridge `WorkItemLifecycleEvent → PlanItem` transitions for devtown. Tests must use mock workers; document this explicitly in the LAYER-LOG when encountered
+- **Merge binding requires a `securitySensitive == false` short-circuit**
+  - Symptom: non-security PRs never satisfy the merge condition — `securityReview` never appears in context, so any `securityReview`-referencing predicate evaluates false or throws
+  - Cause: the merge binding initially only checked `securityReview` approval without a guard for the non-security-sensitive case
+  - Fix: add `when: (.securitySensitive == false) or (.securityReview.outcome == "APPROVED")` short-circuit in both the YAML and the fluent DSL factory. Test `fires_whenNotSecuritySensitiveAndNoSecurityReview` added to cover this path.
+
+- **`quarkus:build` (production package) fails — foundation CDI SPIs unsatisfied**
+  - Symptom: `mvn install` fails during `quarkus:build`; all 108 tests pass; the failure is only in the production packaging phase
+  - Cause: engine CDI SPIs are unsatisfied without claudony + persistence module present. This is a known foundation gap — the harness app cannot be packaged standalone without its full dependency stack.
+  - Status: tracked in devtown#31. Does not affect test coverage or local development.
+
+- **HITL wiring gap (known, deferred)**
+  - `HumanTaskTarget` bindings in the YAML compile and unit-test correctly, but the casehub-work-adapter does not yet bridge `WorkItemLifecycleEvent → PlanItem` transitions for devtown. Full human approval flow is deferred to devtown#30. Tests use mock workers.
 
 ### Pattern to replicate (in another domain)
 
-🔲 To fill when Epic 3 ships. Anticipated steps (check `../aml/LAYER-LOG.md §Layer 5` when available as the reference):
-
-1. Add `casehub-engine` runtime dependency to `{domain}-app` pom
-2. Define goals in YAML: each goal is a JQ predicate over `CaseContext` (e.g. `.reviews | length >= 2`)
-3. Define capabilities in YAML: one per specialist work type, matching `{domain}.ReviewDomain` constants
-4. Define bindings in YAML: `on: { contextChange: {} }`, `when: <JQ predicate over CaseContext>`, `capability: <name>`
-5. Define completion policy: `success: allOf: [goal1, goal2, ...]`
-6. Load YAML at startup via classpath loader — register as `CaseMetaModel` in the engine
-7. Implement `@ApplicationScoped` service (no `@DefaultBean`) in `{domain}-review` that opens a `CaseInstance` when a domain event arrives — displaces the naive service
-8. Unit test binding conditions: use `LambdaExpressionEvaluator` + mock `CaseContext` — no Quarkus required
+1. Create the YAML CasePlanModel in `{domain}-review/src/main/resources/{domain}/` — not in `{domain}-app/`; Quarkus classloader picks it up from the review module JAR at test time
+2. Extend `YamlCaseHub` in `{domain}-app/` with `@ApplicationScoped` — pass the classpath resource path (e.g. `"devtown/pr-review.yaml"`) to `super()`
+3. Create `@ApplicationScoped` (no `@DefaultBean`) service implementing the port interface in `{domain}-app/` — inject the CaseHub bean, build initial CaseContext from the domain payload + policy config, call `caseHub.startCase(initialContext)`
+4. Define scoped policy values via `@ConfigProperty` for now — replace with `PreferenceProvider.resolve(scope).asMap()` when casehub-platform-api ships (parent#26)
+5. Add `casehub-engine` (runtime) and `casehub-engine-testing` (test scope) to `{domain}-app/pom.xml`
+6. Add `InMemoryLedgerEntryRepository` stub to `{domain}-app/src/test/` if `casehub-ledger` runtime is on the classpath (see GE-20260519-e13b01 in the garden)
+7. Write binding condition unit tests using a fluent DSL factory (+ `MapCaseContext` helper) in `{domain}-review/src/test/` — no Quarkus required; tests are fast and cover every binding predicate including short-circuit paths
+8. Write a `@QuarkusTest` in `{domain}-app/src/test/` to verify the YAML loads cleanly, with assertions on expected binding count, goal count, and capability count — catches YAML parse errors and classpath issues at test time
 

--- a/LAYER-LOG.md
+++ b/LAYER-LOG.md
@@ -1,0 +1,131 @@
+# devtown Agentic Harness — Layer Log
+
+Structured record of what was built at each layer, optimised for LLM consumption and future tutorial generation. Correlates with blog entries in `blog/`, git history, and GitHub issues.
+
+Each entry documents one layer of the adoption sequence. Entries are written when work on that layer begins — not before. Sections marked `🔲` within an entry are placeholders: the work for that section isn't done yet, but the expected content or pointer is included so future sessions can fill it in without reconstructing context.
+
+Cross-references:
+- Blog entries: workspace `blog/` (staged; published to mdproctor.github.io/_notes/ via `publish-blog`)
+- Design specs: project `docs/specs/`
+- Improvement log: `docs/PROGRESS.md` (DT-NNN entries)
+- Architecture comparison: `docs/gastown-casehub-analysis-v2.md`
+- Tutorial teaching objectives: `../parent/docs/tutorial-strategy.md §7.5`
+- AML reference implementation: `../aml/LAYER-LOG.md`
+
+---
+
+## Layer 1 — Naive Java (no CaseHub)
+
+**Completed:** Epic 1 (scaffold) 2026-05-08 `10d0d42`; Epic 2 (vocabulary) 2026-05-11 `ccbe944`; 🔲 naive service not yet built
+**Issues:** casehubio/devtown#8 (Epic 1), casehubio/devtown#9 (Epic 2)
+**Design specs:** `docs/specs/2026-05-07-epic1-scaffold-design.md`, `docs/specs/2026-05-08-epic2-domain-model-design.md`
+**Blog:** `blog/2026-05-11-mdp01-the-vocabulary-problem.md` — narrative on the vocabulary split decision
+**Improvement log:** `docs/PROGRESS.md` DT-001 through DT-006
+
+**Key files:**
+- `domain/src/main/java/io/casehub/devtown/domain/ReviewDomain.java` — 6 analytical review capability constants
+- `domain/src/main/java/io/casehub/devtown/domain/AgentQualification.java` — 2 execution capability constants
+- `domain/src/main/java/io/casehub/devtown/domain/HumanDecision.java` — formal PR accountability event constant
+- `domain/src/main/java/io/casehub/devtown/domain/HumanOversight.java` — routing uncertainty constant
+- `domain/src/main/java/io/casehub/devtown/domain/DevtownTrustDimension.java` — 3 quality dimension constants
+- `domain/src/main/java/io/casehub/devtown/domain/RoutingPolicy.java` — configurable routing policy record with `isBootstrap()` and `isBorderline()`
+- `domain/src/main/java/io/casehub/devtown/domain/DevtownCapabilityRegistry.java` — populated default implementation; 10 capabilities, 4 routing policies
+- `domain/src/main/java/io/casehub/devtown/domain/spi/CapabilityRegistry.java` — SPI: `capabilities()`, `policy()`, `isKnown()` default method
+- `app/src/main/java/io/casehub/devtown/app/CapabilityRegistryBean.java` — `@ApplicationScoped` CDI wrapper, zero logic
+- `app/src/test/java/io/casehub/devtown/app/DevtownBootTest.java` — Quarkus boot + CDI discovery verification
+- 🔲 `app/src/main/java/io/casehub/devtown/app/NaivePrReviewService.java` — not yet built; see §What it shows
+- 🔲 `app/src/main/java/io/casehub/devtown/app/PrReviewResource.java` — not yet built; `POST /api/reviews`
+
+### What it shows
+
+Layer 1 has two distinct parts. The first (Epics 1–2, done) establishes the devtown vocabulary — a typed split of what Gastown keeps in a flat namespace. The second (not yet built) shows the naive anti-pattern: direct service calls with no accountability, no SLA, no formal obligation. Together they form the baseline everything else improves upon.
+
+**Part A — Vocabulary and scaffold (Epics 1–2, 2026-05-08 to 2026-05-11)**
+
+The domain model is pure Java, no CaseHub dependencies. The vocabulary split is devtown-specific: Gastown's 13 flat capability tags become four typed classes with distinct routing semantics. This is the first architectural decision an adopter faces and the one with the biggest payoff later — once the foundation wires `TrustGateService`, `ActorType`, and `WorkerSelectionStrategy`, the vocabulary is the application-layer expression of what those foundation capabilities can express. See DT-001 through DT-006 in `docs/PROGRESS.md`.
+
+**Part B — Naive PR review service (🔲 not yet built)**
+
+A `NaivePrReviewService` with `@ApplicationScoped @DefaultBean` that makes direct calls to specialist analysis services. Gap comments name every compliance and accountability gap. A REST endpoint `POST /api/reviews` so the layer is runnable with a single HTTP call. This is the teaching baseline — each subsequent layer displaces it at the CDI level.
+
+Sketch from `../parent/docs/tutorial-strategy.md §7.5.1`:
+
+```java
+// LAYER 1 GAP: no attribution — which agent reviewed this code? No record.
+SecurityAnalysis security = securityAnalyzer.analyze(pr);
+// LAYER 1 GAP: no response SLA — reviewer can sit on this indefinitely.
+ArchitectureReview arch = architectureReviewer.review(pr);
+// LAYER 1 GAP: no formal decline — if an agent can't review, it silently fails or errors.
+// LAYER 1 GAP: no audit trail — cannot trace a production incident back to this review.
+String comment = commentService.post(pr, security, arch);
+```
+
+### The gap comments
+
+🔲 To be written when `NaivePrReviewService` is built. The gap comments are the primary teaching mechanism per layer. Required gaps to name (from CLAUDE.md domain model):
+- No attribution — who reviewed this?
+- No response SLA — reviewer can sit indefinitely
+- No formal DECLINE — scope boundaries not structurally captured
+- No tamper-evident audit trail — cannot trace production incident to missed finding
+- No trust weighting — experienced security reviewer not prioritised over novice
+
+### Key wiring
+
+**Module structure — pure Java domain, Quarkus only in `app/`.**
+`devtown-domain` has zero framework dependencies. All constants, SPI, and default implementation live there. `devtown-app` owns all CDI and Quarkus wiring. This split is mandatory for the tutorial to work — each layer needs to show domain logic independently of the framework.
+
+**`@DefaultBean` displacement pattern (from AML Layer 1).**
+The naive service carries `@DefaultBean`. Each subsequent layer adds an `@ApplicationScoped` implementation without it — CDI displacement means the new one wins, the naive one stays in the build but is inactive. Both classes coexist; no code is deleted across layers.
+
+Expected pattern (`NaivePrReviewService` not yet built — see §What it shows):
+```java
+@ApplicationScoped
+@DefaultBean  // displaced by any @ApplicationScoped impl in the same deployment
+public class NaivePrReviewService implements PrReviewApplicationService {
+```
+
+**`CapabilityRegistry` SPI as vocabulary/registry SPI, not no-op.**
+Platform protocol distinguishes operational no-op SPIs (empty default) from vocabulary/registry SPIs (populated default). `DevtownCapabilityRegistry` is the latter — the default is a fully populated implementation, not a stub. `CapabilityRegistryBean` is a one-liner `@ApplicationScoped` subclass that promotes it to CDI without any logic duplication.
+
+**`isKnown()` as a default method on the SPI interface.**
+Initially written as a concrete method in `DevtownCapabilityRegistry` calling the backing static field directly — not virtual. Commit `ad75f20` fixed it to call `capabilities()` in the implementation; commit `8b3305e` promoted it to a `default` method on the SPI interface. Any subclass overriding `capabilities()` gets a correct `isKnown()` for free. Caught in review — a test specifically for this case (`isKnown` on a subclass that overrides `capabilities()`) would have caught it earlier.
+
+**Vocabulary split rationale.**
+13 flat Gastown tags → 4 typed classes. The split emerged from recognising that `security-review`, `batch-bisect`, and `notify` are not the same kind of thing and should not route through the same trust infrastructure. Full rationale: `docs/gastown-casehub-analysis-v2.md` §DT-001; blog `2026-05-11-mdp01-the-vocabulary-problem.md`.
+
+**`BATCH_BISECT` / `COORDINATED_MERGE` / `COORDINATED_ROLLBACK` are not capability tags.**
+These were in the original Gastown-derived 13-tag vocabulary and removed. They are orchestration operations — expressed as CasePlanModel binding structures in Epics 4/5, not as trust-scored capability strings. Adding them to `DevtownCapabilityRegistry` would mean routing logic evaluating them as agent assignments, which is wrong. Naming review still open: devtown#20.
+
+### Gotchas
+
+- **`isKnown()` returns wrong results on a subclass**
+  - Symptom: a `CapabilityRegistry` subclass that overrides `capabilities()` returns incorrect results from `isKnown()` — capabilities that should be known return false, or vice versa
+  - Cause: initial implementation called the backing static field directly, bypassing the virtual `capabilities()` method. Subclass override was silently ignored.
+  - Fix: `isKnown()` promoted to a `default` method on the SPI interface calling `capabilities()` (`8b3305e`). Write a test for `isKnown()` on a subclass that overrides `capabilities()` before adding the first subclass.
+
+- **Adding `NOTIFY` to the vocabulary causes nonsensical trust threshold checks**
+  - Symptom: `TrustGateService.meetsThreshold()` called with a notification capability tag; threshold evaluation makes no semantic sense for a delivery operation
+  - Cause: `NOTIFY` looks like a capability but is a connector call — it has no trust-scored actor and no quality dimension
+  - Fix: remove from vocabulary; call `casehub-connectors` directly from the case plan model. `NOTIFY` was explicitly removed from the Gastown-derived 13-tag vocabulary for this reason.
+
+- **On day 1, trust-based routing appears identical to Gastown (no differentiation)**
+  - Symptom: routing assigns work to agents without apparent trust weighting; the `RoutingPolicy` thresholds seem to have no effect
+  - Cause: all agents are in bootstrap mode (`isBootstrap()` returns true) because `minimumObservations` hasn't been reached. This is correct — a trust score from 2–3 attestations is noise, not signal. Routing falls back to availability, identical to Gastown's GUPP model.
+  - Fix: no fix required; this is the Phase 0 maturity model by design. Routing quality improves automatically as attestations accumulate. See DT-006 in `docs/PROGRESS.md` for the four-phase model.
+
+### Pattern to replicate (in another domain)
+
+Steps marked `🔲` do not yet have a devtown reference implementation — the pattern is documented from design; the code will exist once Layer 1 is complete.
+
+1. Create `{domain}-domain` Maven module — zero framework imports, zero JPA, no Quarkus
+2. Identify your domain's work types. Ask: are they analytical (trust-scored on quality), operational (trust-scored on outcome), human decisions (with SLA and lifecycle), or system-oversight (triggered by uncertainty)? Create a typed class per category — not a flat string list
+3. Define `RoutingPolicy` values for trust-sensitive capabilities: set `threshold` (minimum trust), `minimumObservations` (credibility gate), `borderlineMargin` (uncertainty band → human oversight), `fallbackType`, and `rationale`
+4. Implement `CapabilityRegistry` SPI in `{domain}.spi` — `capabilities()`, `policy()`, `isKnown()` as default method calling `capabilities()`
+5. Implement the populated default registry in `{domain}` — concrete class, no CDI
+6. Create `{domain}-app` Maven module — depends on `{domain}-domain`; owns all Quarkus wiring
+7. Add a one-liner `@ApplicationScoped` CDI wrapper in `{domain}-app` extending your registry
+8. 🔲 Implement the naive service with `@ApplicationScoped @DefaultBean` — direct calls, no CaseHub, gap comments for every compliance gap
+9. 🔲 Expose `POST /api/{domain-noun}` via a REST resource injecting the port interface
+10. Boot test: verify `@QuarkusTest` starts and CDI discovers the registry bean
+11. 🔲 Test the naive service: plain `new`, no Quarkus — verify gap comments are exercisable
+

--- a/LAYER-LOG.md
+++ b/LAYER-LOG.md
@@ -16,9 +16,9 @@ Cross-references:
 
 ## Layer 1 — Naive Java (no CaseHub)
 
-**Completed:** Epic 1 (scaffold) 2026-05-08 `10d0d42`; Epic 2 (vocabulary) 2026-05-11 `ccbe944`; 🔲 naive service not yet built
-**Issues:** casehubio/devtown#8 (Epic 1), casehubio/devtown#9 (Epic 2)
-**Design specs:** `docs/specs/2026-05-07-epic1-scaffold-design.md`, `docs/specs/2026-05-08-epic2-domain-model-design.md`
+**Completed:** Epic 1 (scaffold) 2026-05-08 `10d0d42`; Epic 2 (vocabulary) 2026-05-11 `ccbe944`; Part B (naive service) 2026-05-15 `cca6acc` + `18b22e0`
+**Issues:** casehubio/devtown#8 (Epic 1), casehubio/devtown#9 (Epic 2), casehubio/devtown#27 (Part B — naive service)
+**Design specs:** `docs/specs/2026-05-07-epic1-scaffold-design.md`, `docs/specs/2026-05-08-epic2-domain-model-design.md`, `docs/specs/2026-05-15-layer1-partb-naive-service-design.md`
 **Blog:** `blog/2026-05-11-mdp01-the-vocabulary-problem.md` — narrative on the vocabulary split decision
 **Improvement log:** `docs/PROGRESS.md` DT-001 through DT-006
 
@@ -33,8 +33,12 @@ Cross-references:
 - `domain/src/main/java/io/casehub/devtown/domain/spi/CapabilityRegistry.java` — SPI: `capabilities()`, `policy()`, `isKnown()` default method
 - `app/src/main/java/io/casehub/devtown/app/CapabilityRegistryBean.java` — `@ApplicationScoped` CDI wrapper, zero logic
 - `app/src/test/java/io/casehub/devtown/app/DevtownBootTest.java` — Quarkus boot + CDI discovery verification
-- 🔲 `app/src/main/java/io/casehub/devtown/app/NaivePrReviewService.java` — not yet built; see §What it shows
-- 🔲 `app/src/main/java/io/casehub/devtown/app/PrReviewResource.java` — not yet built; `POST /api/reviews`
+- `review/src/main/java/io/casehub/devtown/review/PrReviewApplicationService.java` — port interface; CDI displacement boundary for Layer 2+
+- `review/src/main/java/io/casehub/devtown/review/PrPayload.java` — input record: repo, prNumber, headSha, linesChanged
+- `review/src/main/java/io/casehub/devtown/review/PrReviewOutcome.java` — output record: verdict, findings (List<String>)
+- `app/src/main/java/io/casehub/devtown/app/NaivePrReviewService.java` — `@ApplicationScoped @DefaultBean`; 5 gap comments; displaced by Layer 2+
+- `app/src/main/java/io/casehub/devtown/app/PrReviewResource.java` — thin REST dispatcher; `POST /api/reviews`
+- `app/src/test/java/io/casehub/devtown/app/NaivePrReviewServiceTest.java` — plain unit tests; no Quarkus; 3 contract assertions
 
 ### What it shows
 
@@ -44,45 +48,45 @@ Layer 1 has two distinct parts. The first (Epics 1–2, done) establishes the de
 
 The domain model is pure Java, no CaseHub dependencies. The vocabulary split is devtown-specific: Gastown's 13 flat capability tags become four typed classes with distinct routing semantics. This is the first architectural decision an adopter faces and the one with the biggest payoff later — once the foundation wires `TrustGateService`, `ActorType`, and `WorkerSelectionStrategy`, the vocabulary is the application-layer expression of what those foundation capabilities can express. See DT-001 through DT-006 in `docs/PROGRESS.md`.
 
-**Part B — Naive PR review service (🔲 not yet built)**
+**Part B — Naive PR review service (2026-05-15, devtown#27)**
 
-A `NaivePrReviewService` with `@ApplicationScoped @DefaultBean` that makes direct calls to specialist analysis services. Gap comments name every compliance and accountability gap. A REST endpoint `POST /api/reviews` so the layer is runnable with a single HTTP call. This is the teaching baseline — each subsequent layer displaces it at the CDI level.
-
-Sketch from `../parent/docs/tutorial-strategy.md §7.5.1`:
-
-```java
-// LAYER 1 GAP: no attribution — which agent reviewed this code? No record.
-SecurityAnalysis security = securityAnalyzer.analyze(pr);
-// LAYER 1 GAP: no response SLA — reviewer can sit on this indefinitely.
-ArchitectureReview arch = architectureReviewer.review(pr);
-// LAYER 1 GAP: no formal decline — if an agent can't review, it silently fails or errors.
-// LAYER 1 GAP: no audit trail — cannot trace a production incident back to this review.
-String comment = commentService.post(pr, security, arch);
-```
+`NaivePrReviewService` with `@ApplicationScoped @DefaultBean` makes direct stub calls via private methods. Gap comments name every compliance and accountability gap. `PrReviewResource` exposes `POST /api/reviews` so the layer is runnable with a single HTTP call. This is the teaching baseline — each subsequent layer displaces it at the CDI level via a non-`@DefaultBean @ApplicationScoped` implementation.
 
 ### The gap comments
 
-🔲 To be written when `NaivePrReviewService` is built. The gap comments are the primary teaching mechanism per layer. Required gaps to name (from CLAUDE.md domain model):
-- No attribution — who reviewed this?
-- No response SLA — reviewer can sit indefinitely
-- No formal DECLINE — scope boundaries not structurally captured
-- No tamper-evident audit trail — cannot trace production incident to missed finding
-- No trust weighting — experienced security reviewer not prioritised over novice
+From `app/src/main/java/io/casehub/devtown/app/NaivePrReviewService.java`:
+
+```java
+// LAYER 1 GAP: no attribution — which agent ran this analysis? No record.
+var securityFindings = analyzeSecurityDirectly(pr);
+// LAYER 1 GAP: no response SLA — analysis can stall indefinitely with no escalation.
+var architectureFindings = reviewArchitectureDirectly(pr);
+// LAYER 1 GAP: no formal DECLINE — if a specialist can't review, it silently fails or errors.
+// LAYER 1 GAP: no tamper-evident audit trail — cannot trace a production incident to this review.
+// LAYER 1 GAP: no trust weighting — a novice and an expert are treated identically.
+```
 
 ### Key wiring
 
 **Module structure — pure Java domain, Quarkus only in `app/`.**
 `devtown-domain` has zero framework dependencies. All constants, SPI, and default implementation live there. `devtown-app` owns all CDI and Quarkus wiring. This split is mandatory for the tutorial to work — each layer needs to show domain logic independently of the framework.
 
-**`@DefaultBean` displacement pattern (from AML Layer 1).**
-The naive service carries `@DefaultBean`. Each subsequent layer adds an `@ApplicationScoped` implementation without it — CDI displacement means the new one wins, the naive one stays in the build but is inactive. Both classes coexist; no code is deleted across layers.
+**`@DefaultBean` displacement pattern.**
+The naive service carries `@DefaultBean`. Each subsequent layer adds an `@ApplicationScoped` implementation in `review` without it — CDI displacement means the new one wins, the naive one stays in the build but is inactive. Both classes coexist; no code is deleted across layers.
 
-Expected pattern (`NaivePrReviewService` not yet built — see §What it shows):
 ```java
+// app/NaivePrReviewService.java — Layer 1, always present
 @ApplicationScoped
-@DefaultBean  // displaced by any @ApplicationScoped impl in the same deployment
+@DefaultBean  // displaced by any @ApplicationScoped impl without @DefaultBean
 public class NaivePrReviewService implements PrReviewApplicationService {
+
+// review/PrReviewCaseService.java — Layer 5+, displaces the above
+@ApplicationScoped  // no @DefaultBean — takes priority
+public class PrReviewCaseService implements PrReviewApplicationService {
 ```
+
+**Port interface in `review/`, not `app/`.**
+`PrReviewApplicationService`, `PrPayload`, and `PrReviewOutcome` live in `review` (not `app`). Layer 2+ implementations also live in `review` (they depend on `casehub-engine-api`, `casehub-work-api`, etc. — already in the `review` pom). If the port lived in `app`, any `review`-module implementation would need to depend on `app`, creating a module dependency cycle. Caught in code review and fixed in commit `18b22e0`. See §Gotchas.
 
 **`CapabilityRegistry` SPI as vocabulary/registry SPI, not no-op.**
 Platform protocol distinguishes operational no-op SPIs (empty default) from vocabulary/registry SPIs (populated default). `DevtownCapabilityRegistry` is the latter — the default is a fully populated implementation, not a stub. `CapabilityRegistryBean` is a one-liner `@ApplicationScoped` subclass that promotes it to CDI without any logic duplication.
@@ -108,14 +112,17 @@ These were in the original Gastown-derived 13-tag vocabulary and removed. They a
   - Cause: `NOTIFY` looks like a capability but is a connector call — it has no trust-scored actor and no quality dimension
   - Fix: remove from vocabulary; call `casehub-connectors` directly from the case plan model. `NOTIFY` was explicitly removed from the Gastown-derived 13-tag vocabulary for this reason.
 
+- **Port interface placed in `app/` causes a module dependency cycle in Layer 2**
+  - Symptom: `review`-module implementation of `PrReviewApplicationService` cannot be compiled — `review` would need to depend on `app` to access the interface, but `app` already depends on `review`, creating a cycle
+  - Cause: `app` is the runtime assembly; it should consume SPIs, not define them. Ports belong in the module that owns the domain boundary (`review`), not the module that wires everything together (`app`)
+  - Fix: move port interface and DTOs to `review` module (`18b22e0`). Layer 2+ implementations in `review` then implement an interface that also lives in `review` — no cycle
+
 - **On day 1, trust-based routing appears identical to Gastown (no differentiation)**
   - Symptom: routing assigns work to agents without apparent trust weighting; the `RoutingPolicy` thresholds seem to have no effect
   - Cause: all agents are in bootstrap mode (`isBootstrap()` returns true) because `minimumObservations` hasn't been reached. This is correct — a trust score from 2–3 attestations is noise, not signal. Routing falls back to availability, identical to Gastown's GUPP model.
   - Fix: no fix required; this is the Phase 0 maturity model by design. Routing quality improves automatically as attestations accumulate. See DT-006 in `docs/PROGRESS.md` for the four-phase model.
 
 ### Pattern to replicate (in another domain)
-
-Steps marked `🔲` do not yet have a devtown reference implementation — the pattern is documented from design; the code will exist once Layer 1 is complete.
 
 1. Create `{domain}-domain` Maven module — zero framework imports, zero JPA, no Quarkus
 2. Identify your domain's work types. Ask: are they analytical (trust-scored on quality), operational (trust-scored on outcome), human decisions (with SLA and lifecycle), or system-oversight (triggered by uncertainty)? Create a typed class per category — not a flat string list
@@ -124,8 +131,76 @@ Steps marked `🔲` do not yet have a devtown reference implementation — the p
 5. Implement the populated default registry in `{domain}` — concrete class, no CDI
 6. Create `{domain}-app` Maven module — depends on `{domain}-domain`; owns all Quarkus wiring
 7. Add a one-liner `@ApplicationScoped` CDI wrapper in `{domain}-app` extending your registry
-8. 🔲 Implement the naive service with `@ApplicationScoped @DefaultBean` — direct calls, no CaseHub, gap comments for every compliance gap
-9. 🔲 Expose `POST /api/{domain-noun}` via a REST resource injecting the port interface
-10. Boot test: verify `@QuarkusTest` starts and CDI discovers the registry bean
-11. 🔲 Test the naive service: plain `new`, no Quarkus — verify gap comments are exercisable
+8. Define port interface + DTOs in `{domain}-review` module (pure Java, no CDI, no Quarkus) — Layer 2+ implementations also live here; keeping them out of `{domain}-app` prevents a module dependency cycle
+9. Implement the naive service with `@ApplicationScoped @DefaultBean` in `{domain}-app` — direct stub calls, gap comment per compliance gap (no attribution, no SLA, no formal DECLINE, no audit trail, no trust weighting)
+10. Expose `POST /api/{domain-noun}` via a thin REST resource in `{domain}-app` injecting the port interface — auth-retrofit ready (`@RolesAllowed` can be added to the single method without restructuring)
+11. Boot test: run the existing `@QuarkusTest` to verify CDI discovers the naive service and REST resource
+12. Unit test the naive service: plain `new NaiveService()`, no Quarkus — verify non-null outcome, non-blank verdict, non-null findings list
+
+---
+
+## Layer 5 — casehub-engine (adaptive routing on code content)
+
+**Completed:** 🔲 in progress — Epic 3 (devtown#10) started 2026-05-15, brainstorming in progress
+**Issues:** casehubio/devtown#10 (Epic 3: PR review CasePlanModel — content-driven routing and parallel checks)
+**Design specs:** 🔲 to be written — will land in `docs/specs/` when brainstorming completes this session
+**Blog:** 🔲
+**Improvement log:** 🔲 — DT entries to be added as implementation decisions are made
+
+**Key files:**
+- 🔲 `review/src/main/resources/devtown/pr-review.yaml` — YAML CasePlanModel definition; expected when Epic 3 ships. See §What it shows.
+- 🔲 `review/src/main/java/io/casehub/devtown/review/PrReviewCaseService.java` — expected: `@ApplicationScoped` (no `@DefaultBean`); displaces `NaivePrReviewService`. See §Key wiring.
+- 🔲 `review/src/test/java/io/casehub/devtown/review/PrReviewBindingConditionTest.java` — expected: plain unit tests for JQ binding `when` conditions using `LambdaExpressionEvaluator`
+
+### What it shows
+
+Layer 5 introduces casehub-engine into devtown. The PR review case becomes an Adaptive Case Management instance with declared goals and content-driven bindings — security review fires only when code analysis finds security-sensitive code, not from author labels. Multiple checks (style, test coverage, performance) fire simultaneously via the ACM binding system without explicit parallelism declaration. Human approval and CI run in parallel via the WAITING state (total time = max, not sum). The routing logic lives in the case definition YAML and applies consistently to every PR, producing an audit trail of every routing decision.
+
+Contrast with Layer 1: `NaivePrReviewService` makes direct calls with no adaptive routing, no formal obligation, and no audit. Layer 5 displaces it with a `@ApplicationScoped` implementation that opens a `CaseInstance` and lets the engine drive coordination.
+
+See `docs/orchestration-advantages.md` §1 (content-driven routing), §2 (parallel human+CI), §3 (automatic parallelism) for the detailed teaching narrative.
+
+### The gap comments
+
+🔲 To fill when Layer 5 code ships. These are the Layer 1 gap comments that Layer 5 addresses:
+
+```java
+// LAYER 1 GAP: no attribution — which agent ran this analysis? No record.
+// LAYER 1 GAP: no response SLA — analysis can stall indefinitely with no escalation.
+// LAYER 1 GAP: no formal DECLINE — if a specialist can't review, it silently fails or errors.
+// LAYER 1 GAP: no tamper-evident audit trail — cannot trace a production incident to this review.
+// LAYER 1 GAP: no trust weighting — a novice and an expert are treated identically.
+```
+
+Layer 5 closes: attribution (`CaseLedgerEntry` records which binding dispatched which agent), formal DECLINE (DECLINED outcome on blackboard triggers a different binding), audit trail (`CaseLedgerEntry` per case state transition). Partial: SLA (requires casehub-work-adapter HITL wiring — known gap in Epic 3 scope, see CLAUDE.md). Trust weighting (requires P1.3 `TrustWeightedSelectionStrategy` — Layer 6).
+
+### Key wiring
+
+🔲 To fill as Epic 3 implementation decisions are made. Expected areas:
+
+- **YAML loading at startup** — classpath resource loader pattern; check engine test `YamlSimpleCaseHubBeanTest` for how `CaseDefinition` is loaded from YAML and registered as a `CaseMetaModel`
+- **`@DefaultBean` displacement** — `PrReviewCaseService @ApplicationScoped` (no `@DefaultBean`) in `review` displaces `NaivePrReviewService @DefaultBean` in `app`. Same CDI pattern as Layer 1 established; no extra wiring needed
+- **`HumanTaskTarget` binding** — use `HumanTaskTarget.inline()` (not template — casehub-work templates not yet configured in devtown). API: `io.casehub.api.model.HumanTaskTarget`
+- **Binding `when` conditions** — JQ expressions over `CaseContext`; need a committed CaseContext schema defining PR payload fields and code-analysis output fields. Schema design is the first open question in Epic 3 brainstorming (in progress)
+- **`@DefaultBean` on engine no-op SPIs** — any new SPI no-ops must use `@DefaultBean @ApplicationScoped`, not bare `@ApplicationScoped`; see `parent/docs/protocols/engine-spi-noops-defaultbean.md`
+
+### Gotchas
+
+🔲 To fill as encountered during Epic 3 implementation. Known risks:
+
+- **`@ApplicationScoped` no-op SPI in engine without `@DefaultBean`** — collides with devtown's implementation when indexed together via `casehub-testing`. Symptom: CDI ambiguity error on `@QuarkusTest`. Fix: `@DefaultBean @ApplicationScoped` on all engine no-ops. Protocol: `parent/docs/protocols/engine-spi-noops-defaultbean.md`
+- **HITL wiring gap** — `HumanTaskTarget` bindings in the YAML compile but the casehub-work-adapter does not yet bridge `WorkItemLifecycleEvent → PlanItem` transitions for devtown. Tests must use mock workers; document this explicitly in the LAYER-LOG when encountered
+
+### Pattern to replicate (in another domain)
+
+🔲 To fill when Epic 3 ships. Anticipated steps (check `../aml/LAYER-LOG.md §Layer 5` when available as the reference):
+
+1. Add `casehub-engine` runtime dependency to `{domain}-app` pom
+2. Define goals in YAML: each goal is a JQ predicate over `CaseContext` (e.g. `.reviews | length >= 2`)
+3. Define capabilities in YAML: one per specialist work type, matching `{domain}.ReviewDomain` constants
+4. Define bindings in YAML: `on: { contextChange: {} }`, `when: <JQ predicate over CaseContext>`, `capability: <name>`
+5. Define completion policy: `success: allOf: [goal1, goal2, ...]`
+6. Load YAML at startup via classpath loader — register as `CaseMetaModel` in the engine
+7. Implement `@ApplicationScoped` service (no `@DefaultBean`) in `{domain}-review` that opens a `CaseInstance` when a domain event arrives — displaces the naive service
+8. Unit test binding conditions: use `LambdaExpressionEvaluator` + mock `CaseContext` — no Quarkus required
 

--- a/LAYER-LOG.md
+++ b/LAYER-LOG.md
@@ -144,7 +144,7 @@ These were in the original Gastown-derived 13-tag vocabulary and removed. They a
 **Completed:** Epic 3 (devtown#10) shipped 2026-05-19
 **Issues:** casehubio/devtown#10 (Epic 3: PR review CasePlanModel — content-driven routing and parallel checks)
 **Design specs:** `docs/specs/2026-05-15-epic3-pr-review-caseplanmodel-design.md`
-**Blog:** `blog/2026-05-19-mdp01-from-naive-to-adaptive.md` 🔲 (not yet drafted)
+**Blog:** `blog/2026-05-19-mdp01-layer-5-case-definition-lands.md`
 **Improvement log:** `docs/PROGRESS.md` — DT entries to be added as improvement decisions are formalised
 
 **Key files:**

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -56,6 +56,10 @@
     </dependency>
     <dependency>
       <groupId>io.casehub</groupId>
+      <artifactId>casehub-engine-work-adapter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.casehub</groupId>
       <artifactId>casehub-connectors-core</artifactId>
     </dependency>
 
@@ -96,6 +100,11 @@
     <dependency>
       <groupId>io.casehub</groupId>
       <artifactId>casehub-engine-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.casehub</groupId>
+      <artifactId>casehub-engine-persistence-memory</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -108,6 +108,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>io.casehub</groupId>
       <artifactId>casehub-engine-persistence-memory</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -62,6 +62,14 @@
       <groupId>io.casehub</groupId>
       <artifactId>casehub-connectors-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.casehub</groupId>
+      <artifactId>casehub-platform-expression</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.casehub</groupId>
+      <artifactId>casehub-platform</artifactId>
+    </dependency>
 
     <!-- Quarkus extensions -->
     <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -81,10 +81,20 @@
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.casehub</groupId>
+      <artifactId>casehub-platform-api</artifactId>
+    </dependency>
+
     <!-- test -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.casehub</groupId>
+      <artifactId>casehub-platform-testing</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -52,6 +52,10 @@
     </dependency>
     <dependency>
       <groupId>io.casehub</groupId>
+      <artifactId>casehub-engine-scheduler-quartz</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.casehub</groupId>
       <artifactId>casehub-connectors-core</artifactId>
     </dependency>
 
@@ -87,6 +91,11 @@
     <dependency>
       <groupId>io.casehub</groupId>
       <artifactId>casehub-qhorus-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.casehub</groupId>
+      <artifactId>casehub-engine-testing</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -48,6 +48,10 @@
     </dependency>
     <dependency>
       <groupId>io.casehub</groupId>
+      <artifactId>casehub-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.casehub</groupId>
       <artifactId>casehub-connectors-core</artifactId>
     </dependency>
 

--- a/app/src/main/java/io/casehub/devtown/app/NaivePrReviewService.java
+++ b/app/src/main/java/io/casehub/devtown/app/NaivePrReviewService.java
@@ -1,5 +1,8 @@
 package io.casehub.devtown.app;
 
+import io.casehub.devtown.review.PrPayload;
+import io.casehub.devtown.review.PrReviewApplicationService;
+import io.casehub.devtown.review.PrReviewOutcome;
 import io.quarkus.arc.DefaultBean;
 import jakarta.enterprise.context.ApplicationScoped;
 

--- a/app/src/main/java/io/casehub/devtown/app/NaivePrReviewService.java
+++ b/app/src/main/java/io/casehub/devtown/app/NaivePrReviewService.java
@@ -1,0 +1,34 @@
+package io.casehub.devtown.app;
+
+import io.quarkus.arc.DefaultBean;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+@DefaultBean
+public class NaivePrReviewService implements PrReviewApplicationService {
+
+    @Override
+    public PrReviewOutcome review(PrPayload pr) {
+        // LAYER 1 GAP: no attribution — which agent ran this analysis? No record.
+        var securityFindings = analyzeSecurityDirectly(pr);
+        // LAYER 1 GAP: no response SLA — analysis can stall indefinitely with no escalation.
+        var architectureFindings = reviewArchitectureDirectly(pr);
+        // LAYER 1 GAP: no formal DECLINE — if a specialist can't review, it silently fails or errors.
+        // LAYER 1 GAP: no tamper-evident audit trail — cannot trace a production incident to this review.
+        // LAYER 1 GAP: no trust weighting — a novice and an expert are treated identically.
+        var allFindings = new ArrayList<String>(securityFindings);
+        allFindings.addAll(architectureFindings);
+        return new PrReviewOutcome("reviewed", allFindings);
+    }
+
+    private List<String> analyzeSecurityDirectly(PrPayload pr) {
+        return List.of("security-analysis-complete");
+    }
+
+    private List<String> reviewArchitectureDirectly(PrPayload pr) {
+        return List.of("architecture-review-complete");
+    }
+}

--- a/app/src/main/java/io/casehub/devtown/app/NaivePrReviewService.java
+++ b/app/src/main/java/io/casehub/devtown/app/NaivePrReviewService.java
@@ -1,8 +1,11 @@
 package io.casehub.devtown.app;
 
+import io.casehub.devtown.domain.ReviewDomain;
+import io.casehub.devtown.review.PrFinding;
 import io.casehub.devtown.review.PrPayload;
 import io.casehub.devtown.review.PrReviewApplicationService;
 import io.casehub.devtown.review.PrReviewOutcome;
+import io.casehub.devtown.review.PrVerdict;
 import io.quarkus.arc.DefaultBean;
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -22,16 +25,16 @@ public class NaivePrReviewService implements PrReviewApplicationService {
         // LAYER 1 GAP: no formal DECLINE — if a specialist can't review, it silently fails or errors.
         // LAYER 1 GAP: no tamper-evident audit trail — cannot trace a production incident to this review.
         // LAYER 1 GAP: no trust weighting — a novice and an expert are treated identically.
-        var allFindings = new ArrayList<String>(securityFindings);
+        var allFindings = new ArrayList<PrFinding>(securityFindings);
         allFindings.addAll(architectureFindings);
-        return new PrReviewOutcome("reviewed", allFindings);
+        return new PrReviewOutcome(PrVerdict.REVIEWED, allFindings);
     }
 
-    private List<String> analyzeSecurityDirectly(PrPayload pr) {
-        return List.of("security-analysis-complete");
+    private List<PrFinding> analyzeSecurityDirectly(PrPayload pr) {
+        return List.of(new PrFinding(ReviewDomain.SECURITY_REVIEW, "security-analysis-complete"));
     }
 
-    private List<String> reviewArchitectureDirectly(PrPayload pr) {
-        return List.of("architecture-review-complete");
+    private List<PrFinding> reviewArchitectureDirectly(PrPayload pr) {
+        return List.of(new PrFinding(ReviewDomain.ARCHITECTURE_REVIEW, "architecture-review-complete"));
     }
 }

--- a/app/src/main/java/io/casehub/devtown/app/PrPayload.java
+++ b/app/src/main/java/io/casehub/devtown/app/PrPayload.java
@@ -1,0 +1,3 @@
+package io.casehub.devtown.app;
+
+public record PrPayload(String repo, int prNumber, String headSha, int linesChanged) {}

--- a/app/src/main/java/io/casehub/devtown/app/PrReviewApplicationService.java
+++ b/app/src/main/java/io/casehub/devtown/app/PrReviewApplicationService.java
@@ -1,0 +1,5 @@
+package io.casehub.devtown.app;
+
+public interface PrReviewApplicationService {
+    PrReviewOutcome review(PrPayload pr);
+}

--- a/app/src/main/java/io/casehub/devtown/app/PrReviewCaseHub.java
+++ b/app/src/main/java/io/casehub/devtown/app/PrReviewCaseHub.java
@@ -1,0 +1,12 @@
+package io.casehub.devtown.app;
+
+import io.casehub.api.engine.YamlCaseHub;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PrReviewCaseHub extends YamlCaseHub {
+
+    public PrReviewCaseHub() {
+        super("devtown/pr-review.yaml");
+    }
+}

--- a/app/src/main/java/io/casehub/devtown/app/PrReviewCaseService.java
+++ b/app/src/main/java/io/casehub/devtown/app/PrReviewCaseService.java
@@ -1,0 +1,52 @@
+package io.casehub.devtown.app;
+
+import io.casehub.devtown.review.PrPayload;
+import io.casehub.devtown.review.PrReviewApplicationService;
+import io.casehub.devtown.review.PrReviewOutcome;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class PrReviewCaseService implements PrReviewApplicationService {
+
+    private static final String VERDICT_CASE_OPENED = "case-opened";
+
+    @Inject
+    PrReviewCaseHub caseHub;
+
+    @ConfigProperty(name = "devtown.policy.human-approval-threshold", defaultValue = "500")
+    int humanApprovalThreshold;
+
+    @ConfigProperty(name = "devtown.policy.security-review-required", defaultValue = "true")
+    boolean securityReviewRequired;
+
+    @ConfigProperty(name = "devtown.policy.require-senior-approval", defaultValue = "false")
+    boolean requireSeniorApproval;
+
+    @Override
+    public PrReviewOutcome review(PrPayload pr) {
+        // TODO(parent#26): replace @ConfigProperty injection with PreferenceProvider.resolve(scope).asMap()
+        var policy = Map.<String, Object>of(
+            "humanApprovalThreshold", humanApprovalThreshold,
+            "securityReviewRequired", securityReviewRequired,
+            "requireSeniorApproval", requireSeniorApproval
+        );
+        var prContext = Map.<String, Object>of(
+            "id", String.valueOf(pr.prNumber()),
+            "repo", pr.repo(),
+            "linesChanged", pr.linesChanged(),
+            "baseRef", pr.baseRef(),
+            "headSha", pr.headSha()
+        );
+        var initialContext = Map.<String, Object>of(
+            "pr", prContext,
+            "policy", policy
+        );
+        // CompletionStage<UUID> case ID — not surfaced in PrReviewOutcome until Layer 6 adds case tracking (devtown#10)
+        caseHub.startCase(initialContext);
+        return new PrReviewOutcome(VERDICT_CASE_OPENED, List.of());
+    }
+}

--- a/app/src/main/java/io/casehub/devtown/app/PrReviewOutcome.java
+++ b/app/src/main/java/io/casehub/devtown/app/PrReviewOutcome.java
@@ -1,0 +1,5 @@
+package io.casehub.devtown.app;
+
+import java.util.List;
+
+public record PrReviewOutcome(String verdict, List<String> findings) {}

--- a/app/src/main/java/io/casehub/devtown/app/PrReviewResource.java
+++ b/app/src/main/java/io/casehub/devtown/app/PrReviewResource.java
@@ -1,0 +1,25 @@
+package io.casehub.devtown.app;
+
+import io.casehub.devtown.review.PrPayload;
+import io.casehub.devtown.review.PrReviewApplicationService;
+import io.casehub.devtown.review.PrReviewOutcome;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/api/reviews")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class PrReviewResource {
+
+    @Inject
+    PrReviewApplicationService service;
+
+    @POST
+    public PrReviewOutcome review(PrPayload pr) {
+        return service.review(pr);
+    }
+}

--- a/app/src/main/java/io/casehub/devtown/app/SlaBreachHandler.java
+++ b/app/src/main/java/io/casehub/devtown/app/SlaBreachHandler.java
@@ -1,0 +1,35 @@
+package io.casehub.devtown.app;
+
+import io.casehub.work.api.BreachDecision;
+import io.casehub.work.runtime.event.SlaBreachEvent;
+import io.casehub.workadapter.CallerRef;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class SlaBreachHandler {
+
+    private static final Logger LOG = Logger.getLogger(SlaBreachHandler.class);
+
+    @Inject PrReviewCaseHub caseHub;
+
+    void onBreach(@Observes SlaBreachEvent event) {
+        try {
+            CallerRef ref = CallerRef.parse(event.context().task().callerRef());
+            if (ref == null) return;
+
+            switch (event.decision()) {
+                case BreachDecision.Fail fail ->
+                    caseHub.signal(ref.caseId(), "humanApproval",
+                        Map.of("status", fail.reason()));
+                default -> {}
+            }
+        } catch (Exception e) {
+            LOG.errorf(e, "SlaBreachHandler failed for callerRef=%s — case may not be signaled",
+                event.context().task().callerRef());
+        }
+    }
+}

--- a/app/src/main/java/io/casehub/devtown/app/SlaBreachPolicyBean.java
+++ b/app/src/main/java/io/casehub/devtown/app/SlaBreachPolicyBean.java
@@ -1,0 +1,7 @@
+package io.casehub.devtown.app;
+
+import io.casehub.devtown.domain.sla.DefaultSlaBreachPolicy;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SlaBreachPolicyBean extends DefaultSlaBreachPolicy {}

--- a/app/src/main/java/io/casehub/devtown/app/spi/DevtownCaseInstanceRepository.java
+++ b/app/src/main/java/io/casehub/devtown/app/spi/DevtownCaseInstanceRepository.java
@@ -1,0 +1,7 @@
+package io.casehub.devtown.app.spi;
+
+import io.casehub.persistence.memory.InMemoryCaseInstanceRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class DevtownCaseInstanceRepository extends InMemoryCaseInstanceRepository {}

--- a/app/src/main/java/io/casehub/devtown/app/spi/DevtownCaseMetaModelRepository.java
+++ b/app/src/main/java/io/casehub/devtown/app/spi/DevtownCaseMetaModelRepository.java
@@ -1,0 +1,7 @@
+package io.casehub.devtown.app.spi;
+
+import io.casehub.persistence.memory.InMemoryCaseMetaModelRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class DevtownCaseMetaModelRepository extends InMemoryCaseMetaModelRepository {}

--- a/app/src/main/java/io/casehub/devtown/app/spi/DevtownEventLogRepository.java
+++ b/app/src/main/java/io/casehub/devtown/app/spi/DevtownEventLogRepository.java
@@ -1,0 +1,7 @@
+package io.casehub.devtown.app.spi;
+
+import io.casehub.persistence.memory.InMemoryEventLogRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class DevtownEventLogRepository extends InMemoryEventLogRepository {}

--- a/app/src/main/java/io/casehub/devtown/app/spi/DevtownSubCaseGroupRepository.java
+++ b/app/src/main/java/io/casehub/devtown/app/spi/DevtownSubCaseGroupRepository.java
@@ -1,0 +1,7 @@
+package io.casehub.devtown.app.spi;
+
+import io.casehub.persistence.memory.MemorySubCaseGroupRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class DevtownSubCaseGroupRepository extends MemorySubCaseGroupRepository {}

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -16,6 +16,12 @@ quarkus.http.port=8080
 %prod.quarkus.index-dependency.casehub-engine-common.group-id=io.casehub
 %prod.quarkus.index-dependency.casehub-engine-common.artifact-id=casehub-engine-common
 
+# ── Engine persistence SPIs — in-memory for Layer 1-2 development ─────────────────
+# Devtown provides @ApplicationScoped @Default subclasses of the in-memory SPI
+# implementations in casehub-engine-persistence-memory. These satisfy the four engine
+# CDI injection sites without requiring selected-alternatives activation.
+# Replace with casehub-engine-persistence-hibernate (devtown#40) for a PostgreSQL backend.
+
 # GitHub integration — set via environment
 # devtown.github.token=${GITHUB_TOKEN:}
 # devtown.github.base-url=https://api.github.com

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,5 +1,21 @@
 quarkus.http.port=8080
 
+# ── ARC bean exclusions (production only) ─────────────────────────────────────
+# CasehubWorkloadProvider (engine-internal) conflicts with JpaWorkloadProvider (casehub-work).
+# It should be @DefaultBean in the engine (tracked in engine issue) — excluded here as workaround.
+# %prod. scope: tests manage WorkloadProvider disambiguation via src/test/resources/application.properties.
+%prod.quarkus.arc.exclude-types=io.casehub.engine.internal.worker.CasehubWorkloadProvider
+
+# ── Jandex index — engine modules without embedded index ───────────────────────
+# casehub-engine and casehub-engine-common lack Jandex indices (engine doesn't configure
+# jandex-maven-plugin per module). Force Quarkus to index them for CDI bean discovery.
+# %prod. scope prevents these from being applied during @QuarkusTest augmentation,
+# which manages engine bean discovery separately via src/test/resources/application.properties.
+%prod.quarkus.index-dependency.casehub-engine.group-id=io.casehub
+%prod.quarkus.index-dependency.casehub-engine.artifact-id=casehub-engine
+%prod.quarkus.index-dependency.casehub-engine-common.group-id=io.casehub
+%prod.quarkus.index-dependency.casehub-engine-common.artifact-id=casehub-engine-common
+
 # GitHub integration — set via environment
 # devtown.github.token=${GITHUB_TOKEN:}
 # devtown.github.base-url=https://api.github.com

--- a/app/src/test/java/io/casehub/devtown/app/HumanApprovalLifecycleTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/HumanApprovalLifecycleTest.java
@@ -1,0 +1,148 @@
+package io.casehub.devtown.app;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.model.CaseStatus;
+import io.casehub.engine.spi.CaseInstanceRepository;
+import io.casehub.work.runtime.event.WorkItemLifecycleEvent;
+import io.casehub.work.runtime.model.WorkItem;
+import io.casehub.work.runtime.service.WorkItemService;
+import io.casehub.workadapter.WorkItemLifecycleAdapter;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class HumanApprovalLifecycleTest {
+
+    @Inject PrReviewCaseHub          caseHub;
+    @Inject WorkItemQueries          workItemQueries;
+    @Inject WorkItemService          workItemService;
+    @Inject CaseInstanceRepository   caseInstanceRepository;
+    @Inject WorkItemCompletionCapture completionCapture;
+    @Inject WorkItemLifecycleAdapter  lifecycleAdapter;
+
+    @Test
+    void humanApproval_fullLifecycle()
+            throws ExecutionException, InterruptedException, TimeoutException {
+
+        // Initial context: all parallel checks pre-seeded with non-APPROVED values.
+        // - Suppresses all capability bindings (ci, style, test, perf are non-null →
+        //   conditions ".x == null" are false → no tryProvision() calls → Vert.x free).
+        // - Keeps pr-approved goal unsatisfied (PENDING ≠ APPROVED) so the case stays
+        //   active while the human-approval WorkItem lifecycle plays out.
+        var pr = Map.<String, Object>of(
+                "id", "42",
+                "repo", "casehubio/devtown",
+                "linesChanged", 600,       // > humanApprovalThreshold of 500
+                "baseRef", "main",
+                "headSha", "abc123");
+        var policy = Map.<String, Object>of(
+                "humanApprovalThreshold", 500,
+                "securityReviewRequired", false,
+                "requireSeniorApproval", false);
+        var codeAnalysis = Map.<String, Object>of(
+                "complete", true,
+                "securitySensitive", false,
+                "architectureCrossing", false);
+
+        var initialContext = Map.<String, Object>of(
+                "pr", pr,
+                "policy", policy,
+                "codeAnalysis", codeAnalysis,
+                "styleCheck",         Map.of("outcome", "PENDING"),
+                "testCoverage",       Map.of("outcome", "PENDING"),
+                "performanceAnalysis", Map.of("outcome", "PENDING"),
+                "ci",                 Map.of("status", "passing"));
+
+        // ── Checkpoint 1: start the case ──────────────────────────────────────
+        UUID caseId = caseHub.startCase(initialContext)
+                .toCompletableFuture()
+                .get(5, SECONDS);
+        assertThat(caseId).isNotNull();
+
+        // ── Checkpoint 2: WorkItem created by the human-approval binding ───────
+        // HumanTaskScheduleHandler (blocking=true) creates the WorkItem asynchronously.
+        // engine#312: the binding may fire twice → accept ≥1 WorkItem.
+        await().atMost(5, SECONDS)
+                .pollInterval(100, MILLISECONDS)
+                .untilAsserted(() -> {
+                    var items = workItemQueries.scanAll().stream()
+                            .filter(i -> isHumanApprovalFor(i, caseId))
+                            .toList();
+                    assertThat(items).as("human-approval WorkItem").isNotEmpty();
+                    assertThat(items.get(0).title).isEqualTo("PR approval required");
+                });
+
+        // ── Checkpoint 3: complete WorkItems and drive the adapter ─────────────
+        // Resolution {"status":"approved"} with outputMapping "{ humanApproval: . }"
+        // (engine#314 — flat outputMapping required because nested {..} not supported).
+        // → humanApproval = {status:"approved"} in case context.
+        var toComplete = workItemQueries.scanAll().stream()
+                .filter(i -> isHumanApprovalFor(i, caseId))
+                .toList();
+
+        toComplete.forEach(wi -> workItemService.completeFromSystem(
+                wi.id, "system", "{\"status\": \"approved\"}"));
+
+        // CDI @ObservesAsync delivery is verified via test-scope bean (not the external
+        // adapter — engine#315 tracks @ObservesAsync for indexed external jar observers).
+        await().atMost(3, SECONDS)
+                .pollInterval(100, MILLISECONDS)
+                .untilAsserted(() -> toComplete.forEach(wi ->
+                        assertThat(completionCapture.wasCompleted(wi.id))
+                                .as("@ObservesAsync CDI delivery for WorkItem " + wi.id)
+                                .isTrue()));
+
+        // Re-fetch completed WorkItems and invoke the adapter directly.
+        // Tests the full outputMapping → case context → CONTEXT_CHANGED chain.
+        var completedItems = workItemQueries.scanAll().stream()
+                .filter(i -> isHumanApprovalFor(i, caseId))
+                .toList();
+        completedItems.forEach(wi -> lifecycleAdapter.onWorkItemLifecycle(
+                WorkItemLifecycleEvent.of("COMPLETED", wi, "system", wi.resolution)));
+
+        // ── Checkpoint 4: case context updated via outputMapping ──────────────
+        await().atMost(5, SECONDS)
+                .pollInterval(100, MILLISECONDS)
+                .untilAsserted(() -> {
+                    var instance = caseInstanceRepository
+                            .findByUuid(caseId)
+                            .await().atMost(Duration.ofSeconds(2));
+                    assertThat(instance).isNotNull();
+                    Object status = instance.getCaseContext().getPath("humanApproval.status");
+                    assertThat(status)
+                            .as("humanApproval.status should be 'approved' after outputMapping")
+                            .isEqualTo("approved");
+                });
+
+        // ── Checkpoint 5: case completes when all goals are satisfied ──────────
+        // Signal the APPROVED values that were intentionally absent (kept pr-approved
+        // unsatisfied while the WorkItem was live).
+        caseHub.signal(caseId, "styleCheck",          Map.of("outcome", "APPROVED"));
+        caseHub.signal(caseId, "testCoverage",         Map.of("outcome", "APPROVED"));
+        caseHub.signal(caseId, "performanceAnalysis",  Map.of("outcome", "APPROVED"));
+
+        await().atMost(5, SECONDS)
+                .pollInterval(100, MILLISECONDS)
+                .untilAsserted(() -> {
+                    var instance = caseInstanceRepository
+                            .findByUuid(caseId)
+                            .await().atMost(Duration.ofSeconds(2));
+                    assertThat(instance).isNotNull();
+                    assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+                });
+    }
+
+    private static boolean isHumanApprovalFor(final WorkItem item, final UUID caseId) {
+        return item.callerRef != null && item.callerRef.contains(caseId.toString());
+    }
+}

--- a/app/src/test/java/io/casehub/devtown/app/InMemoryLedgerEntryRepository.java
+++ b/app/src/test/java/io/casehub/devtown/app/InMemoryLedgerEntryRepository.java
@@ -1,0 +1,124 @@
+package io.casehub.devtown.app;
+
+import io.casehub.ledger.runtime.model.LedgerAttestation;
+import io.casehub.ledger.runtime.model.LedgerEntry;
+import io.casehub.ledger.runtime.repository.ReactiveLedgerEntryRepository;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * In-memory stub for {@link ReactiveLedgerEntryRepository} — satisfies CDI
+ * resolution in @QuarkusTest without a real database.
+ *
+ * <p>LAYER 1 GAP (tutorial note): no persistence, no Merkle chain, no privacy
+ * suppression. A production deployment wires the real Panache implementation.</p>
+ */
+@ApplicationScoped
+class InMemoryLedgerEntryRepository implements ReactiveLedgerEntryRepository {
+
+    private final List<LedgerEntry> entries = new CopyOnWriteArrayList<>();
+    private final List<LedgerAttestation> attestations = new CopyOnWriteArrayList<>();
+
+    @Override
+    public Uni<LedgerEntry> save(LedgerEntry entry) {
+        entries.add(entry);
+        return Uni.createFrom().item(entry);
+    }
+
+    @Override
+    public Uni<List<LedgerEntry>> listAll() {
+        return Uni.createFrom().item(new ArrayList<>(entries));
+    }
+
+    @Override
+    public Uni<List<LedgerEntry>> findBySubjectId(UUID subjectId) {
+        return Uni.createFrom().item(
+            entries.stream().filter(e -> subjectId.equals(e.subjectId)).toList());
+    }
+
+    // Stub returns — these methods are not exercised in Layer 1 tests.
+    // Implement against the in-memory list if a test exercises these paths.
+
+    @Override
+    public Uni<List<LedgerEntry>> findBySubjectIdAndTimeRange(UUID subjectId, Instant from, Instant to) {
+        return Uni.createFrom().item(List.of());
+    }
+
+    @Override
+    public Uni<Optional<LedgerEntry>> findLatestBySubjectId(UUID subjectId) {
+        return Uni.createFrom().item(
+            entries.stream()
+                .filter(e -> subjectId.equals(e.subjectId))
+                .max(java.util.Comparator.comparing(e -> e.occurredAt)));
+    }
+
+    @Override
+    public Uni<Optional<LedgerEntry>> findEntryById(UUID id) {
+        return Uni.createFrom().item(
+            entries.stream().filter(e -> id.equals(e.id)).findFirst());
+    }
+
+    @Override
+    public Uni<List<LedgerEntry>> findAllEvents() {
+        return listAll();
+    }
+
+    @Override
+    public Uni<List<LedgerEntry>> findByActorId(String actorId, Instant from, Instant to) {
+        return Uni.createFrom().item(List.of());
+    }
+
+    @Override
+    public Uni<List<LedgerEntry>> findByActorRole(String role, Instant from, Instant to) {
+        return Uni.createFrom().item(List.of());
+    }
+
+    @Override
+    public Uni<List<LedgerEntry>> findByTimeRange(Instant from, Instant to) {
+        return Uni.createFrom().item(List.of());
+    }
+
+    @Override
+    public Uni<List<LedgerEntry>> findCausedBy(UUID causeId) {
+        return Uni.createFrom().item(List.of());
+    }
+
+    @Override
+    public Uni<LedgerAttestation> saveAttestation(LedgerAttestation attestation) {
+        attestations.add(attestation);
+        return Uni.createFrom().item(attestation);
+    }
+
+    @Override
+    public Uni<List<LedgerAttestation>> findAttestationsByEntryId(UUID entryId) {
+        return Uni.createFrom().item(List.of());
+    }
+
+    @Override
+    public Uni<Map<UUID, List<LedgerAttestation>>> findAttestationsForEntries(Set<UUID> entryIds) {
+        return Uni.createFrom().item(Map.of());
+    }
+
+    @Override
+    public Uni<List<LedgerAttestation>> findAttestationsByEntryIdAndCapabilityTag(UUID entryId, String tag) {
+        return Uni.createFrom().item(List.of());
+    }
+
+    @Override
+    public Uni<List<LedgerAttestation>> findAttestationsByEntryIdGlobal(UUID entryId) {
+        return Uni.createFrom().item(List.of());
+    }
+
+    @Override
+    public Uni<List<LedgerAttestation>> findAttestationsByAttestorIdAndCapabilityTag(String attestorId, String tag) {
+        return Uni.createFrom().item(List.of());
+    }
+}

--- a/app/src/test/java/io/casehub/devtown/app/NaivePrReviewServiceTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/NaivePrReviewServiceTest.java
@@ -1,0 +1,31 @@
+package io.casehub.devtown.app;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NaivePrReviewServiceTest {
+
+    private final NaivePrReviewService service = new NaivePrReviewService();
+
+    @Test
+    void review_returnsNonNullOutcome() {
+        var pr = new PrPayload("casehubio/devtown", 42, "abc123", 150);
+        var outcome = service.review(pr);
+        assertThat(outcome).isNotNull();
+    }
+
+    @Test
+    void review_verdictIsNonBlank() {
+        var pr = new PrPayload("casehubio/devtown", 42, "abc123", 150);
+        var outcome = service.review(pr);
+        assertThat(outcome.verdict()).isNotBlank();
+    }
+
+    @Test
+    void review_findingsIsNonNull() {
+        var pr = new PrPayload("casehubio/devtown", 42, "abc123", 150);
+        var outcome = service.review(pr);
+        assertThat(outcome.findings()).isNotNull();
+    }
+}

--- a/app/src/test/java/io/casehub/devtown/app/NaivePrReviewServiceTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/NaivePrReviewServiceTest.java
@@ -1,6 +1,7 @@
 package io.casehub.devtown.app;
 
 import io.casehub.devtown.review.PrPayload;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,25 +9,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 class NaivePrReviewServiceTest {
 
     private final NaivePrReviewService service = new NaivePrReviewService();
+    private PrPayload pr;
+
+    @BeforeEach
+    void setUp() {
+        pr = new PrPayload("casehubio/devtown", 42, "abc123", "main", 150);
+    }
 
     @Test
     void review_returnsNonNullOutcome() {
-        var pr = new PrPayload("casehubio/devtown", 42, "abc123", "main", 150);
-        var outcome = service.review(pr);
-        assertThat(outcome).isNotNull();
+        assertThat(service.review(pr)).isNotNull();
     }
 
     @Test
     void review_verdictIsNonBlank() {
-        var pr = new PrPayload("casehubio/devtown", 42, "abc123", "main", 150);
-        var outcome = service.review(pr);
-        assertThat(outcome.verdict()).isNotBlank();
+        assertThat(service.review(pr).verdict()).isNotBlank();
     }
 
     @Test
     void review_findingsIsNonNull() {
-        var pr = new PrPayload("casehubio/devtown", 42, "abc123", "main", 150);
-        var outcome = service.review(pr);
-        assertThat(outcome.findings()).isNotNull();
+        assertThat(service.review(pr).findings()).isNotNull();
     }
 }

--- a/app/src/test/java/io/casehub/devtown/app/NaivePrReviewServiceTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/NaivePrReviewServiceTest.java
@@ -11,21 +11,21 @@ class NaivePrReviewServiceTest {
 
     @Test
     void review_returnsNonNullOutcome() {
-        var pr = new PrPayload("casehubio/devtown", 42, "abc123", 150);
+        var pr = new PrPayload("casehubio/devtown", 42, "abc123", "main", 150);
         var outcome = service.review(pr);
         assertThat(outcome).isNotNull();
     }
 
     @Test
     void review_verdictIsNonBlank() {
-        var pr = new PrPayload("casehubio/devtown", 42, "abc123", 150);
+        var pr = new PrPayload("casehubio/devtown", 42, "abc123", "main", 150);
         var outcome = service.review(pr);
         assertThat(outcome.verdict()).isNotBlank();
     }
 
     @Test
     void review_findingsIsNonNull() {
-        var pr = new PrPayload("casehubio/devtown", 42, "abc123", 150);
+        var pr = new PrPayload("casehubio/devtown", 42, "abc123", "main", 150);
         var outcome = service.review(pr);
         assertThat(outcome.findings()).isNotNull();
     }

--- a/app/src/test/java/io/casehub/devtown/app/NaivePrReviewServiceTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/NaivePrReviewServiceTest.java
@@ -1,5 +1,6 @@
 package io.casehub.devtown.app;
 
+import io.casehub.devtown.review.PrPayload;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/app/src/test/java/io/casehub/devtown/app/PrReviewCaseHubTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/PrReviewCaseHubTest.java
@@ -1,0 +1,54 @@
+package io.casehub.devtown.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class PrReviewCaseHubTest {
+
+    @Inject PrReviewCaseHub caseHub;
+
+    @Test
+    void definitionLoads() {
+        var def = caseHub.getDefinition();
+        assertThat(def).isNotNull();
+        assertThat(def.getNamespace()).isEqualTo("devtown");
+        assertThat(def.getName()).isEqualTo("pr-review");
+        assertThat(def.getVersion()).isEqualTo("1.0.0");
+    }
+
+    @Test
+    void hasNineBindings() {
+        var def = caseHub.getDefinition();
+        assertThat(def.getBindings()).hasSize(9);
+        var names = def.getBindings().stream().map(b -> b.getName()).toList();
+        assertThat(names).containsExactlyInAnyOrder(
+            "initial-analysis", "run-ci",
+            "security-review", "architecture-review", "style-check",
+            "test-coverage", "performance-analysis",
+            "human-approval", "merge");
+    }
+
+    @Test
+    void hasThreeGoals() {
+        var def = caseHub.getDefinition();
+        assertThat(def.getGoals()).hasSize(3);
+        var names = def.getGoals().stream().map(g -> g.getName()).toList();
+        assertThat(names).containsExactlyInAnyOrder("pr-approved", "security-verified", "ci-passing");
+    }
+
+    @Test
+    void hasNineCapabilities() {
+        var def = caseHub.getDefinition();
+        assertThat(def.getCapabilities()).hasSize(9);
+    }
+
+    @Test
+    void hasCompletion() {
+        var def = caseHub.getDefinition();
+        assertThat(def.getCompletion()).isNotNull();
+    }
+}

--- a/app/src/test/java/io/casehub/devtown/app/PrReviewCaseHubTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/PrReviewCaseHubTest.java
@@ -43,9 +43,10 @@ class PrReviewCaseHubTest {
     }
 
     @Test
-    void hasNineCapabilities() {
+    void hasEightCapabilities() {
         var def = caseHub.getDefinition();
-        assertThat(def.getCapabilities()).hasSize(9);
+        // human-decision:pr-approval removed — human-approval now uses humanTask binding target
+        assertThat(def.getCapabilities()).hasSize(8);
     }
 
     @Test

--- a/app/src/test/java/io/casehub/devtown/app/PrReviewCaseHubTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/PrReviewCaseHubTest.java
@@ -2,6 +2,8 @@ package io.casehub.devtown.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Goal;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -24,7 +26,7 @@ class PrReviewCaseHubTest {
     void hasNineBindings() {
         var def = caseHub.getDefinition();
         assertThat(def.getBindings()).hasSize(9);
-        var names = def.getBindings().stream().map(b -> b.getName()).toList();
+        var names = def.getBindings().stream().map(Binding::getName).toList();
         assertThat(names).containsExactlyInAnyOrder(
             "initial-analysis", "run-ci",
             "security-review", "architecture-review", "style-check",
@@ -36,7 +38,7 @@ class PrReviewCaseHubTest {
     void hasThreeGoals() {
         var def = caseHub.getDefinition();
         assertThat(def.getGoals()).hasSize(3);
-        var names = def.getGoals().stream().map(g -> g.getName()).toList();
+        var names = def.getGoals().stream().map(Goal::getName).toList();
         assertThat(names).containsExactlyInAnyOrder("pr-approved", "security-verified", "ci-passing");
     }
 

--- a/app/src/test/java/io/casehub/devtown/app/PrReviewResourceTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/PrReviewResourceTest.java
@@ -1,0 +1,29 @@
+package io.casehub.devtown.app;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestHTTPEndpoint(PrReviewResource.class)
+class PrReviewResourceTest {
+
+    @Test
+    void postReview_returns200WithOutcome() {
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("""
+                {"repo":"casehubio/devtown","prNumber":42,"headSha":"abc123","baseRef":"main","linesChanged":150}
+                """)
+        .when()
+            .post()
+        .then()
+            .statusCode(200)
+            .body("verdict", notNullValue())
+            .body("findings", notNullValue());
+    }
+}

--- a/app/src/test/java/io/casehub/devtown/app/SlaBreachHandlerWiringTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/SlaBreachHandlerWiringTest.java
@@ -1,0 +1,75 @@
+package io.casehub.devtown.app;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.engine.spi.CaseInstanceRepository;
+import io.casehub.platform.api.path.Path;
+import io.casehub.platform.api.preferences.MapPreferences;
+import io.casehub.work.api.BreachDecision;
+import io.casehub.work.api.BreachType;
+import io.casehub.work.api.BreachedTask;
+import io.casehub.work.api.SlaBreachContext;
+import io.casehub.work.api.SlaBreachPolicy;
+import io.casehub.work.runtime.event.SlaBreachEvent;
+import io.casehub.workadapter.CallerRef;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class SlaBreachHandlerWiringTest {
+
+    @Inject SlaBreachPolicy        policy;
+    @Inject PrReviewCaseHub        caseHub;
+    @Inject Event<SlaBreachEvent>  breachEvents;
+    @Inject CaseInstanceRepository caseInstanceRepository;
+
+    // linesChanged=100 < humanApprovalThreshold=500 — human-approval binding does not fire.
+    // All other bindings suppressed by pre-seeding (PP-20260521-134c38).
+    // Case stays active: pr-approved goal requires styleCheck.outcome==APPROVED but it is PENDING.
+    private static final Map<String, Object> MINIMAL_CTX = Map.of(
+            "pr",                  Map.of("id", "wt1", "repo", "r", "linesChanged", 100,
+                                           "baseRef", "main", "headSha", "abc"),
+            "policy",              Map.of("humanApprovalThreshold", 500,
+                                          "securityReviewRequired", false,
+                                          "requireSeniorApproval", false),
+            "codeAnalysis",        Map.of("complete", true, "securitySensitive", false,
+                                           "architectureCrossing", false),
+            "styleCheck",          Map.of("outcome", "PENDING"),
+            "testCoverage",        Map.of("outcome", "PENDING"),
+            "performanceAnalysis", Map.of("outcome", "PENDING"),
+            "ci",                  Map.of("status", "passing"));
+
+    @Test
+    void slaBreachPolicyBean_displaces_noOp() {
+        assertThat(policy).isInstanceOf(SlaBreachPolicyBean.class);
+    }
+
+    @Test
+    void slaBreachHandler_onFail_signalsCaseContext() throws Exception {
+        UUID caseId = caseHub.startCase(MINIMAL_CTX).toCompletableFuture().get(5, SECONDS);
+        assertThat(caseId).isNotNull();
+
+        String callerRef = CallerRef.encode(caseId, "human-approval");
+        var task = new BreachedTask(UUID.randomUUID(), callerRef,
+                                    "PR approval", Set.of("pr-leads"));
+        var ctx  = new SlaBreachContext(BreachType.CLAIM_EXPIRED, task,
+                                        Path.root(), new MapPreferences(Map.of()));
+        breachEvents.fire(new SlaBreachEvent(ctx, new BreachDecision.Fail("sla-breach")));
+
+        await().atMost(5, SECONDS).pollInterval(100, MILLISECONDS).untilAsserted(() -> {
+            var instance = caseInstanceRepository.findByUuid(caseId)
+                    .await().atMost(Duration.ofSeconds(2));
+            assertThat(instance.getCaseContext().getPath("humanApproval.status"))
+                    .isEqualTo("sla-breach");
+        });
+    }
+}

--- a/app/src/test/java/io/casehub/devtown/app/SlaBreachLifecycleTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/SlaBreachLifecycleTest.java
@@ -1,0 +1,124 @@
+package io.casehub.devtown.app;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.engine.spi.CaseInstanceRepository;
+import io.casehub.work.runtime.model.WorkItem;
+import io.casehub.work.runtime.model.WorkItemStatus;
+import io.casehub.work.runtime.repository.WorkItemStore;
+import io.casehub.work.runtime.service.ExpiryLifecycleService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class SlaBreachLifecycleTest {
+
+    @Inject PrReviewCaseHub        caseHub;
+    @Inject WorkItemQueries        workItemQueries;
+    @Inject WorkItemStore          workItemStore;
+    @Inject ExpiryLifecycleService expiryService;
+    @Inject CaseInstanceRepository caseInstanceRepository;
+
+    @Test
+    void twoTierSlaBreach_signalsCaseOnTerminalFail() throws Exception {
+
+        var pr = Map.<String, Object>of(
+                "id", "99", "repo", "casehubio/devtown",
+                "linesChanged", 600, "baseRef", "main", "headSha", "def456");
+        var policy = Map.<String, Object>of(
+                "humanApprovalThreshold", 500,
+                "securityReviewRequired", false,
+                "requireSeniorApproval", false);
+        var initialCtx = Map.<String, Object>of(
+                "pr", pr,
+                "policy", policy,
+                "codeAnalysis",        Map.of("complete", true,
+                                               "securitySensitive", false,
+                                               "architectureCrossing", false),
+                "styleCheck",          Map.of("outcome", "PENDING"),
+                "testCoverage",        Map.of("outcome", "PENDING"),
+                "performanceAnalysis", Map.of("outcome", "PENDING"),
+                "ci",                  Map.of("status", "passing"));
+
+        // ── Checkpoint 1: start case ──────────────────────────────────────────
+        UUID caseId = caseHub.startCase(initialCtx)
+                .toCompletableFuture().get(5, SECONDS);
+        assertThat(caseId).isNotNull();
+
+        // ── Checkpoint 2: WorkItem created with candidateGroups=pr-reviewers ──
+        await().atMost(5, SECONDS).pollInterval(100, MILLISECONDS).untilAsserted(() -> {
+            var items = workItemQueries.scanAll().stream()
+                    .filter(i -> isHumanApprovalFor(i, caseId)).toList();
+            assertThat(items).as("human-approval WorkItem").hasSize(1);
+            assertThat(items.get(0).candidateGroups)
+                    .as("candidateGroups from YAML").isEqualTo("pr-reviewers");
+            assertThat(items.get(0).expiresAt)
+                    .as("expiresAt set from expiresIn: PT24H").isNotNull();
+        });
+
+        // ── Checkpoint 3: trigger Tier 1 breach ───────────────────────────────
+        expireWorkItem(caseId);
+        expiryService.checkExpired();
+
+        await().atMost(3, SECONDS).pollInterval(100, MILLISECONDS).untilAsserted(() -> {
+            var items = workItemQueries.scanAll().stream()
+                    .filter(i -> isHumanApprovalFor(i, caseId)).toList();
+            assertThat(items).hasSize(1);
+            assertThat(items.get(0).candidateGroups)
+                    .as("escalated to pr-leads").isEqualTo("pr-leads");
+            assertThat(items.get(0).status)
+                    .as("WorkItem is PENDING again after in-place escalation")
+                    .isEqualTo(WorkItemStatus.PENDING);
+        });
+
+        // Case context unchanged after Tier 1 (only Fail triggers case signal)
+        var instanceAfterTier1 = caseInstanceRepository.findByUuid(caseId)
+                .await().atMost(java.time.Duration.ofSeconds(2));
+        assertThat(instanceAfterTier1.getCaseContext().getPath("humanApproval"))
+                .as("humanApproval context unchanged after escalation").isNull();
+
+        // ── Checkpoint 4: trigger Tier 2 breach ───────────────────────────────
+        expireWorkItem(caseId);
+        expiryService.checkExpired();
+
+        await().atMost(5, SECONDS).pollInterval(100, MILLISECONDS).untilAsserted(() -> {
+            var instance = caseInstanceRepository.findByUuid(caseId)
+                    .await().atMost(java.time.Duration.ofSeconds(2));
+            assertThat(instance).isNotNull();
+            Object status = instance.getCaseContext().getPath("humanApproval.status");
+            assertThat(status)
+                    .as("humanApproval.status should be sla-breach after terminal breach")
+                    .isEqualTo("sla-breach");
+        });
+
+        // WorkItem itself should be EXPIRED with resolution set
+        var finalItems = workItemQueries.scanAll().stream()
+                .filter(i -> isHumanApprovalFor(i, caseId)).toList();
+        assertThat(finalItems).hasSize(1);
+        assertThat(finalItems.get(0).status).isEqualTo(WorkItemStatus.EXPIRED);
+        assertThat(finalItems.get(0).resolution).isEqualTo("sla-breach");
+    }
+
+    @Transactional
+    void expireWorkItem(UUID caseId) {
+        workItemQueries.scanAll().stream()
+                .filter(i -> isHumanApprovalFor(i, caseId)
+                          && i.status == WorkItemStatus.PENDING)
+                .forEach(i -> {
+                    i.expiresAt = Instant.now().minusSeconds(60);
+                    workItemStore.put(i);
+                });
+    }
+
+    private static boolean isHumanApprovalFor(WorkItem item, UUID caseId) {
+        return item.callerRef != null && item.callerRef.contains(caseId.toString());
+    }
+}

--- a/app/src/test/java/io/casehub/devtown/app/SlaBreachLifecycleTest.java
+++ b/app/src/test/java/io/casehub/devtown/app/SlaBreachLifecycleTest.java
@@ -119,6 +119,6 @@ class SlaBreachLifecycleTest {
     }
 
     private static boolean isHumanApprovalFor(WorkItem item, UUID caseId) {
-        return item.callerRef != null && item.callerRef.contains(caseId.toString());
+        return item.callerRef != null && item.callerRef.startsWith("case:" + caseId);
     }
 }

--- a/app/src/test/java/io/casehub/devtown/app/WorkItemCompletionCapture.java
+++ b/app/src/test/java/io/casehub/devtown/app/WorkItemCompletionCapture.java
@@ -1,0 +1,29 @@
+package io.casehub.devtown.app;
+
+import io.casehub.work.runtime.event.WorkItemLifecycleEvent;
+import io.casehub.work.runtime.model.WorkItemStatus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.ObservesAsync;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Test-scope bean that captures async WorkItem lifecycle events.
+ * Used by HumanApprovalLifecycleTest to verify @ObservesAsync delivery.
+ */
+@ApplicationScoped
+class WorkItemCompletionCapture {
+
+    private final ConcurrentMap<UUID, WorkItemLifecycleEvent> completed = new ConcurrentHashMap<>();
+
+    void onCompleted(@ObservesAsync WorkItemLifecycleEvent event) {
+        if (event.status() == WorkItemStatus.COMPLETED) {
+            completed.put(event.workItemId(), event);
+        }
+    }
+
+    boolean wasCompleted(final UUID workItemId) {
+        return completed.containsKey(workItemId);
+    }
+}

--- a/app/src/test/java/io/casehub/devtown/app/WorkItemQueries.java
+++ b/app/src/test/java/io/casehub/devtown/app/WorkItemQueries.java
@@ -1,0 +1,19 @@
+package io.casehub.devtown.app;
+
+import io.casehub.work.runtime.model.WorkItem;
+import io.casehub.work.runtime.repository.WorkItemStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.List;
+
+@ApplicationScoped
+class WorkItemQueries {
+
+    @Inject WorkItemStore store;
+
+    @Transactional
+    List<WorkItem> scanAll() {
+        return store.scanAll();
+    }
+}

--- a/app/src/test/resources/application.properties
+++ b/app/src/test/resources/application.properties
@@ -14,6 +14,11 @@ quarkus.index-dependency.qhorus-testing.artifact-id=casehub-qhorus-testing
 quarkus.index-dependency.engine-testing.group-id=io.casehub
 quarkus.index-dependency.engine-testing.artifact-id=casehub-engine-testing
 
+# Index engine-common so engine.internal.jq.JQEvaluator @ApplicationScoped bean is discoverable.
+# Required after engine#316 — WorkOrchestrator, CaseContextChangedEventHandler etc. now inject it.
+quarkus.index-dependency.engine-common.group-id=io.casehub
+quarkus.index-dependency.engine-common.artifact-id=casehub-engine-common
+
 # Index engine-scheduler-quartz so JobScheduler + WorkerExecutionManager CDI beans are discoverable in tests
 quarkus.index-dependency.engine-scheduler-quartz.group-id=io.casehub
 quarkus.index-dependency.engine-scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz

--- a/app/src/test/resources/application.properties
+++ b/app/src/test/resources/application.properties
@@ -1,12 +1,26 @@
+# Random port — avoids conflicts when test suites run in parallel
 quarkus.http.test-port=0
 
 # casehub-qhorus 0.2-SNAPSHOT embeds properties that strict config validation rejects
 # as unmapped (SRCFG00050) when the extension descriptor isn't registered at augmentation
 smallrye.config.mapping.validate-unknown=false
+# TODO: remove once casehub-qhorus registers its extension descriptor at augmentation (casehubio/qhorus#N)
 
 # Index qhorus-testing jar so InMemory*Store CDI beans are discoverable in tests
 quarkus.index-dependency.qhorus-testing.group-id=io.casehub
 quarkus.index-dependency.qhorus-testing.artifact-id=casehub-qhorus-testing
+
+# Index engine-testing jar so Test*Repository CDI beans are discoverable in tests
+quarkus.index-dependency.engine-testing.group-id=io.casehub
+quarkus.index-dependency.engine-testing.artifact-id=casehub-engine-testing
+
+# Index engine-scheduler-quartz so JobScheduler + WorkerExecutionManager CDI beans are discoverable in tests
+quarkus.index-dependency.engine-scheduler-quartz.group-id=io.casehub
+quarkus.index-dependency.engine-scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
+
+# Resolve CDI ambiguity: engine provides CasehubWorkloadProvider as the bridge;
+# exclude JpaWorkloadProvider so the engine's bridge is the unique @Default bean.
+quarkus.arc.exclude-types=io.casehub.work.runtime.service.JpaWorkloadProvider
 
 # Qhorus named datasource — in-memory H2 for tests
 %test.quarkus.datasource.qhorus.jdbc.url=jdbc:h2:mem:devtown-qhorus-test;DB_CLOSE_ON_EXIT=FALSE

--- a/app/src/test/resources/application.properties
+++ b/app/src/test/resources/application.properties
@@ -43,7 +43,10 @@ quarkus.arc.exclude-types=io.casehub.work.runtime.service.JpaWorkloadProvider
 # This activates MemorySubCaseGroupRepository globally for augmentation (safe because this
 # file is in src/test/resources and only on the test classpath).
 # Required because casehub-engine-blackboard (via work-adapter) injects SubCaseGroupRepository.
-quarkus.arc.selected-alternatives=io.casehub.persistence.memory.MemorySubCaseGroupRepository,io.casehub.persistence.memory.MemoryPlanItemStore
+# MemoryPlanItemStore is still activated explicitly — no Devtown default subclass for PlanItemStore.
+# DevtownSubCaseGroupRepository (@ApplicationScoped) replaces the MemorySubCaseGroupRepository
+# activation; no need to select MemorySubCaseGroupRepository here anymore.
+quarkus.arc.selected-alternatives=io.casehub.persistence.memory.MemoryPlanItemStore
 
 # Qhorus named datasource — in-memory H2 for tests
 %test.quarkus.datasource.qhorus.jdbc.url=jdbc:h2:mem:devtown-qhorus-test;DB_CLOSE_ON_EXIT=FALSE

--- a/app/src/test/resources/application.properties
+++ b/app/src/test/resources/application.properties
@@ -38,7 +38,7 @@ quarkus.arc.exclude-types=io.casehub.work.runtime.service.JpaWorkloadProvider
 # This activates MemorySubCaseGroupRepository globally for augmentation (safe because this
 # file is in src/test/resources and only on the test classpath).
 # Required because casehub-engine-blackboard (via work-adapter) injects SubCaseGroupRepository.
-quarkus.arc.selected-alternatives=io.casehub.persistence.memory.MemorySubCaseGroupRepository
+quarkus.arc.selected-alternatives=io.casehub.persistence.memory.MemorySubCaseGroupRepository,io.casehub.persistence.memory.MemoryPlanItemStore
 
 # Qhorus named datasource — in-memory H2 for tests
 %test.quarkus.datasource.qhorus.jdbc.url=jdbc:h2:mem:devtown-qhorus-test;DB_CLOSE_ON_EXIT=FALSE

--- a/app/src/test/resources/application.properties
+++ b/app/src/test/resources/application.properties
@@ -50,7 +50,6 @@ quarkus.arc.selected-alternatives=io.casehub.persistence.memory.MemoryPlanItemSt
 
 # Qhorus named datasource — in-memory H2 for tests
 %test.quarkus.datasource.qhorus.jdbc.url=jdbc:h2:mem:devtown-qhorus-test;DB_CLOSE_ON_EXIT=FALSE
-%test.quarkus.datasource.qhorus.reactive=false
 %test.quarkus.flyway.qhorus.migrate-at-start=false
 %test.quarkus.hibernate-orm.qhorus.database.generation=drop-and-create
 

--- a/app/src/test/resources/application.properties
+++ b/app/src/test/resources/application.properties
@@ -18,9 +18,27 @@ quarkus.index-dependency.engine-testing.artifact-id=casehub-engine-testing
 quarkus.index-dependency.engine-scheduler-quartz.group-id=io.casehub
 quarkus.index-dependency.engine-scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
 
+# Index work-adapter so HumanTaskScheduleHandler + WorkItemLifecycleAdapter CDI beans are discoverable
+quarkus.index-dependency.engine-work-adapter.group-id=io.casehub
+quarkus.index-dependency.engine-work-adapter.artifact-id=casehub-engine-work-adapter
+
+# Index blackboard (transitive via work-adapter) so BlackboardRegistry bean is discoverable
+quarkus.index-dependency.engine-blackboard.group-id=io.casehub
+quarkus.index-dependency.engine-blackboard.artifact-id=casehub-engine-blackboard
+
+# Index persistence-memory so MemorySubCaseGroupRepository (needed by blackboard) is discoverable
+quarkus.index-dependency.engine-persistence-memory.group-id=io.casehub
+quarkus.index-dependency.engine-persistence-memory.artifact-id=casehub-engine-persistence-memory
+
 # Resolve CDI ambiguity: engine provides CasehubWorkloadProvider as the bridge;
 # exclude JpaWorkloadProvider so the engine's bridge is the unique @Default bean.
 quarkus.arc.exclude-types=io.casehub.work.runtime.service.JpaWorkloadProvider
+
+# Note: quarkus.arc.selected-alternatives is a build-time property — %test. prefix has no effect.
+# This activates MemorySubCaseGroupRepository globally for augmentation (safe because this
+# file is in src/test/resources and only on the test classpath).
+# Required because casehub-engine-blackboard (via work-adapter) injects SubCaseGroupRepository.
+quarkus.arc.selected-alternatives=io.casehub.persistence.memory.MemorySubCaseGroupRepository
 
 # Qhorus named datasource — in-memory H2 for tests
 %test.quarkus.datasource.qhorus.jdbc.url=jdbc:h2:mem:devtown-qhorus-test;DB_CLOSE_ON_EXIT=FALSE

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,27 @@
+# casehub-devtown — Design
+
+## Architecture
+
+_To be documented._
+
+## Module Structure
+
+| Module | Type | Purpose |
+|--------|------|---------|
+| _(add modules)_ | | |
+
+## Key Abstractions
+
+_To be documented._
+
+## SPI Contracts
+
+_To be documented._
+
+## Data Model
+
+_To be documented._
+
+## Configuration
+
+_To be documented._

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -29,7 +29,7 @@ Each gate is a foundation capability devtown depends on. Status shown here; full
 | P0.2 qhorus#123 — commitment outcomes → `LedgerAttestation` | ✅ DONE | 2026-04-28 | DONE → SOUND, FAILURE → FLAGGED, DECLINE → FLAGGED; `TrustScoreJob` now has input; trust model active |
 | P0.3 ledger#47 — `ActorTypeResolver` + all consumers updated | ✅ DONE | 2026-04-29 | Canonical `actorId` derivation across all repos; trust accumulates consistently |
 | P0.3 qhorus#124 — `InstanceActorIdProvider` SPI | ✅ DONE (SPI) | 2026-04-29 | SPI contract defined; `DefaultInstanceActorIdProvider` shipped |
-| P0.3 qhorus#124 — claudony persona→session mapping | ⚠️ PENDING | — | Trust accumulates per persona across sessions, not per ephemeral session; required before routing reflects long-term trust |
+| P0.3 qhorus#124 — claudony persona→session mapping | ✅ DONE | 2026-05-03 | `ClaudonyInstanceActorIdProvider` (claudony#107) maps `claudony-worker-{uuid}` → `claude:{roleName}@v1`. Trust now accumulates per persona across sessions. Closed feedback loop is end-to-end. |
 
 ### P1 — Scale and Quality
 
@@ -46,16 +46,16 @@ Each gate is a foundation capability devtown depends on. Status shown here; full
 | Gate | Status | Date | Unlocks for devtown |
 |------|--------|------|---------------------|
 | casehub-work work#157 — GitHub Issues sync | ✅ DONE | — | WorkItems sync to GitHub Issues; human review tasks visible in standard tooling |
-| parent#6 — SLA propagation case→WorkItem | ⚠️ PENDING | — | Case-level deadlines flow into human review WorkItems; SLA enforcement end-to-end |
-| casehub-work-adapter — HITL wiring (WorkItem COMPLETED → case signal) | ⚠️ PENDING | — | Human review completion unblocks case progression; end-to-end human-in-the-loop |
+| parent#6 — SLA propagation case→WorkItem | ✅ DONE | 2026-05-20 | Engine-side: `HumanTaskScheduleHandler` applies `min(taskDeadline, caseBudgetDeadline)` from `PropagationContext.caseBudgetDeadline`. Claudony Commitment deadline bounding still deferred (no COMMAND-creation code yet). |
+| casehub-work-adapter — HITL wiring (WorkItem COMPLETED → case signal) | ✅ DONE (happy path) | 2026-05-23 | devtown#33 wired; devtown#30 e2e test passes. Escalation-during-wait path ⚠️ still pending: `ExpiryLifecycleService` escalation doesn't signal engine (work#225, blocked on engine#349 `CaseSignalSink` SPI). |
 
 ### What devtown can build today
 
-Based on ✅ gates: case plan models, content-driven routing bindings, capability vocabulary, trust dimension tracking, parallel AI checks, cryptographic audit of case decisions, GitHub Issues sync for human review tasks.
+Based on ✅ gates: case plan models, content-driven routing bindings (Layer 5 ✅), capability vocabulary, trust dimension tracking, parallel AI checks, cryptographic audit of case decisions, GitHub Issues sync for human review tasks, Layer 2 SLA-bounded human review gate with escalation (devtown#41 ✅), HITL end-to-end happy path (devtown#33, devtown#30 ✅), trust accumulation per persona across sessions (qhorus#124 ✅).
 
-**Blocked until qhorus#124:** trust routing that reflects long-term agent reputation (scores accumulate per session only).
-**Blocked until P1.3:** routing thresholds enforced at assignment (design complete; enforcement not yet wired).
-**Blocked until HITL wiring:** full human-in-the-loop PR approval cycles.
+**Blocked until P1.3 (engine#336 + engine#337 → TrustWeightedSelectionStrategy):** routing thresholds enforced at assignment. Note: qhorus#199 (`TrustGateService` never called at COMMAND creation) is an additional prerequisite — trust scores are computed but not checked when obligations open.
+**Blocked until engine#349 (`CaseSignalSink` SPI):** complete escalation-during-wait signal path (work#225).
+**Blocked until engine#326 (failure goal support):** SLA breach → case FAILED transition for Layer 2 complete path.
 
 ---
 
@@ -84,7 +84,7 @@ Design decisions that produce capabilities Gastown structurally cannot match. Ea
 ### DT-002 — Two distinct human involvement types: decision and oversight
 
 **Status:** ✅ Implemented — Epic 2 (devtown#9)
-**Requires:** casehub-work ✅; HITL wiring ⚠️ (for end-to-end); qhorus#124 ⚠️ (for trust to accumulate per human persona)
+**Requires:** casehub-work ✅; HITL wiring ✅ (happy path devtown#33); qhorus#124 ✅ claudony#107 (trust accumulates per persona); escalation-during-wait ⚠️ (work#225, engine#349)
 
 | | devtown | Gastown |
 |---|---|---|
@@ -99,7 +99,7 @@ Design decisions that produce capabilities Gastown structurally cannot match. Ea
 ### DT-003 — Trust dimensions grounded in normative layer, not duplicating capability scoring
 
 **Status:** ✅ Implemented — Epic 2 (devtown#9)
-**Requires:** P0.2 ✅; #68 ✅; qhorus#124 ⚠️ (for SCOPE_CALIBRATION to accumulate per persona)
+**Requires:** P0.2 ✅; #68 ✅; qhorus#124 ✅ claudony#107 (SCOPE_CALIBRATION now accumulates per persona)
 
 | | devtown | Gastown |
 |---|---|---|
@@ -115,7 +115,7 @@ Design decisions that produce capabilities Gastown structurally cannot match. Ea
 ### DT-004 — Routing thresholds as configurable policy, not hard-coded constants
 
 **Status:** ✅ Implemented — Epic 2 (devtown#9)
-**Requires:** P1.3 ⚠️ (for thresholds to be enforced at assignment); P0.2 ✅ (for trust scores to exist)
+**Requires:** P1.3 ⚠️ (engine#336 + engine#337 prerequisites open; qhorus#199 also blocks enforcement); P0.2 ✅
 
 | | devtown | Gastown |
 |---|---|---|
@@ -131,7 +131,7 @@ Design decisions that produce capabilities Gastown structurally cannot match. Ea
 ### DT-005 — `RoutingPolicy`: trust-aware routing with uncertainty handling and audit rationale
 
 **Status:** ✅ Implemented — Epic 2 (devtown#9)
-**Requires:** P0.2 ✅ (trust scores exist); P1.3 ⚠️ (enforcement at assignment); ledger#76 ⚠️ (per-capability quality floors, additive extension)
+**Requires:** P0.2 ✅; P1.3 ⚠️ (enforcement at assignment); ledger#76 ✅ DONE 2026-05-15 — `CAPABILITY_DIMENSION` score type with `scope_key = "{capabilityTag}:{dimensionName}"`
 
 | | devtown | Gastown |
 |---|---|---|
@@ -149,7 +149,7 @@ Design decisions that produce capabilities Gastown structurally cannot match. Ea
 ### DT-006 — Trust maturity model: four phases from bootstrap to adaptive routing
 
 **Status:** ✅ Implemented — Epic 2 (devtown#9)
-**Requires:** P0.2 ✅ (attestations exist to accumulate); P1.3 ⚠️ (enforcement at assignment); ledger#76 ⚠️ (Phase 3 quality floors)
+**Requires:** P0.2 ✅; P1.3 ⚠️ (enforcement at assignment); ledger#76 ✅ DONE 2026-05-15 (Phase 3 `CAPABILITY_DIMENSION` quality floors now available)
 
 | | devtown | Gastown |
 |---|---|---|
@@ -171,4 +171,71 @@ Design decisions that produce capabilities Gastown structurally cannot match. Ea
 
 **Why devtown can do this, Gastown cannot:** Gastown is permanently in Phase 0 — it has no trust model to mature. The GUPP model has no concept of "this agent now has enough history that we can trust their score." devtown starts identically to Gastown (Phase 0) and automatically improves routing as evidence accumulates. The maturity model means the architectural sophistication is always appropriate to the data that exists — no ceremony, no manual trust seeding, no configuration changes required at deployment time.
 
-**Platform pattern:** the maturity model is not devtown-specific. Any CaseHub application using trust-based routing faces the cold-start problem. The four-phase model and `minimumObservations` gate are a reusable methodology tracked for PLATFORM.md (parent#14).
+**Platform pattern:** the maturity model is not devtown-specific. Any CaseHub application using trust-based routing faces the cold-start problem. The four-phase model and `minimumObservations` gate are documented in PLATFORM.md (parent#14 closed 2026-05-21).
+
+---
+
+### DT-007 — Layer 2: SLA-bounded human review gate with two-tier escalation
+
+**Status:** ✅ Implemented — devtown#41 (code), devtown#42 (wiring test)
+**Requires:** casehub-work SlaBreachPolicy SPI ✅ (work#212–213); casehub-work-adapter HITL ✅ (devtown#33); engine#326 ⚠️ (failure goal — SLA breach → case FAILED transition pending)
+
+| | devtown | Gastown |
+|---|---|---|
+| **First SLA breach** | `SlaBreachPolicyBean.onBreach(BreachDecision.EscalateTo)` — WorkItem `candidateGroups` rotates to `pr-leads`, status reset to PENDING for reassignment | No equivalent — bead assigned to human same as agent, no differentiation, no escalation |
+| **Second SLA breach** | `SlaBreachHandler.onFail()` signals case context `{status: "sla-breach"}` via `caseHub.signal()`, triggering binding re-evaluation | No equivalent |
+| **SLA policy** | `DefaultSlaBreachPolicy` — stateless, two-tier, configurable via `SlaPreferenceKey`. Displaces no-op bean at CDI level; subsequent layers can further displace | N/A |
+| **Obligation lifecycle** | WorkItem carries formal SLA timer, escalation path, audit entry per state transition | Bead has a timeout but no formal obligation lifecycle |
+
+**Why devtown can do this, Gastown cannot:** Gastown's GUPP model assigns work to humans identically to agents — bead on hook, no differentiation, no escalation chain, no formal SLA enforcement. The `SlaBreachPolicy` SPI (casehub-work#213) provides a purpose-built HITL obligation lifecycle: timers, candidateGroup rotation, and case-context signaling on terminal breach. This is possible because casehub-work treats human task completion as a first-class normative event, not just a delivery acknowledgement.
+
+---
+
+### DT-008 — Content-driven binding routing: specialist review fires on code content, not author labels
+
+**Status:** ✅ Implemented — devtown#10 (Epic 3 CasePlanModel)
+**Requires:** engine P0.1 ✅
+
+| | devtown | Gastown |
+|---|---|---|
+| **Security review trigger** | `when: .securitySensitive == true` — fires only if code analysis placed this flag in case context; author labelling has no effect | Formula step with role directive — author or operator declares whether security review is needed |
+| **Automatic parallelism** | Multiple checks (style, test coverage, performance) fire simultaneously when their binding conditions are satisfied by the same context update — no explicit parallel declaration | Explicit formula structure required to express parallelism |
+| **Human + CI in parallel** | Human approval and CI check enter WAITING state simultaneously — total wall time = max(approval, CI), not sum | Sequential by default; explicit convoy structure to express overlap |
+| **Routing audit** | Every binding dispatch recorded in EventLog as a case fact — why security review ran (or didn't) is queryable | No routing rationale captured |
+
+**Why devtown can do this, Gastown cannot:** Gastown uses formula steps (TOML) with explicit sequence and role directives. Content-driven conditional dispatch — route to specialist only if the content warrants it — requires a rule evaluation engine over accumulated blackboard state. CaseHub's binding system evaluates JQ predicates over CaseContext on every `CONTEXT_CHANGED` event: content analysis runs first, specialist review fires only if analysis finds security-sensitive code. Gastown has no equivalent to predicate-gated, content-reactive routing. **Note:** as of engine#335, the `when:` field is evaluated via `contextChange.filter` at the engine level — the application-level unit tests confirm correctness independently.
+
+---
+
+### DT-009 — Ed25519 bilateral agent signing: non-repudiation beyond admin trust
+
+**Status:** ✅ Implemented (foundation — inherited by all domain apps) — ledger#79, #80, #83, #84
+**Requires:** casehub-ledger ✅
+
+| | devtown (via foundation) | Gastown |
+|---|---|---|
+| **Platform signing** | Ed25519-signed COMMAND — agent cannot claim it never received an instruction | Dolt history is admin-trusted; a database admin can rewrite history |
+| **Agent signing** | Ed25519-signed RESPONSE — platform cannot deny what the agent returned | No equivalent |
+| **Bilateral** | Both sides sign; neither can unilaterally repudiate | N/A |
+| **Compromise detection** | Signature verification failure fires CDI event for real-time alerting | N/A |
+| **Key rotation** | Key versioning with rotation history; each entry carries `signingKeyVersion` | N/A |
+| **Post-quantum path** | Algorithm-transparent SPI; ADR documenting PQC migration path (ledger#84) | N/A |
+| **Third-party verification** | Ed25519-signed Merkle checkpoints publishable to external transparency log; verifiable without server access | Verification requires server access |
+
+**Why devtown can do this, Gastown cannot:** Gastown's tamper-evidence model stops at Dolt's git-level audit — the database admin is the trusted party. CaseHub's bilateral Ed25519 signing means: (a) agents cannot dispute having received a COMMAND or issued a RESPONSE, (b) Merkle inclusion proofs are verifiable by any third party without server access, (c) signing key compromise is detected and alerted in real time. This capability is inherited automatically by all domain applications including devtown without any application-layer implementation.
+
+---
+
+### DT-010 — Trust federation: cross-deployment reputation via ledger export/import
+
+**Status:** ✅ Implemented (foundation — inherited by all domain apps) — ledger#63, #64, #65 (shipped 2026-05-14)
+**Requires:** casehub-ledger ✅
+
+| | devtown (via foundation) | Gastown |
+|---|---|---|
+| **Export** | `TrustExportService` — publishes `ActorTrustScore` deltas in canonical format, endpoint behind config flag | Wasteland stamps travel across organizations via DoltHub — production-ready |
+| **Import** | `TrustImportService` SPI — consumes trust deltas from external deployments, seeds Beta(α,β) priors | N/A |
+| **Trust basis** | Cryptographically derived from attested outcomes (DONE → SOUND, FAILURE/DECLINE → FLAGGED) — imported trust carries mathematical guarantees of Bayesian Beta model | Human-curated stamps — not automatically derived from attested outcomes |
+| **Cold start** | New agent: Beta(1,1) prior; with imported trust: Beta(α,β) seeded from external history — bootstraps immediately | No equivalent bootstrapping mechanism |
+
+**Why devtown can do this, Gastown cannot:** Gastown's Wasteland is more mature (production-ready, portable). CaseHub now has structural parity with `TrustExportService` + `TrustImportService` (P2.1 complete). The architectural difference: Gastown's stamps are human-curated — a trusted person assigns them. CaseHub's exported trust is automatically derived from cryptographically attested commitment outcomes. Imported trust carries the same mathematical provenance as locally-computed trust, making cross-deployment reputation structurally more reliable than stamp-based models.

--- a/docs/contributor-trust-proposal.md
+++ b/docs/contributor-trust-proposal.md
@@ -1,0 +1,91 @@
+# Contributor Trust for PR Routing
+
+**The problem:** AI-generated PRs are flooding open source projects. Reviewers can't keep up. Manual triage doesn't scale.
+
+**The idea:** Route PRs by contributor reputation — built automatically from outcomes, not assigned manually.
+
+---
+
+## How it works
+
+**Contributors earn a trust score from PR history:**
+
+| Event | Score impact |
+|-------|-------------|
+| PR merged, first submission | Rises |
+| PR returned for rework | Drops |
+| PR rejected | Drops faster |
+
+**Score feeds directly into queue priority:**
+
+| Queue | Who lands here |
+|-------|---------------|
+| Fast-track | High-trust contributors |
+| Borderline | Promising but limited history |
+| Triage | New or low-trust accounts — ordered by file-path risk |
+| Security | Any PR touching sensitive paths, regardless of trust |
+
+**No history = triage. Always.** A slop generator that creates a new account every PR can never escape triage — their score never builds because their PRs don't merge.
+
+---
+
+## The scoring model
+
+- Uses **Bayesian Beta** — the same model used in medical trial analysis and A/B testing
+- Tracks *confidence* alongside success rate — 2 PRs merged ≠ 200 PRs merged
+- Requires a configurable minimum number of observations before acting on a score
+- **Bootstrapped from existing history on day one** — GitHub's API gives us years of PR data before the system goes live
+
+---
+
+## Vouching
+
+Genuine newcomers have no history. Vouching solves this.
+
+- A high-trust contributor sponsors a newcomer → newcomer gets a score boost
+- **The voucher's own score is at risk** if the vouchee's PRs get returned
+- Uses **EigenTrust** (same family as PageRank) — a vouch from a 10-year committer carries more weight than one from a recent joiner
+- Can only vouch for contributors with lower trust than you — no inflation rings
+
+---
+
+## How it fits DevTown
+
+DevTown already routes PRs to the right *reviewer* by trust. This adds the same model to the *intake* side.
+
+```
+PR arrives → contributor trust → queue priority
+                                       ↓
+                            reviewer routing (existing)
+                                       ↓
+                            outcomes update both scores
+```
+
+One trust ledger. One pipeline. Not two apps.
+
+**Internal teams:** set minimum observations to zero — everyone pre-trusted. System operates as reviewer routing only.  
+**Open source:** both sides active. Full pipeline.
+
+---
+
+## What's already built
+
+| Capability | Status |
+|-----------|--------|
+| Bayesian Beta scoring model | ✅ In platform |
+| EigenTrust propagation | ✅ In platform |
+| Work queues + labels + SLA tracking | ✅ In platform |
+| Cryptographic audit trail | ✅ In platform |
+| GitHub event integration | 🔲 To build |
+| History mining (bootstrap) | 🔲 To build |
+| Vouching UI | 🔲 To build |
+| Contributor score visibility | 🔲 To build |
+
+---
+
+## Open questions
+
+- Score scope: per-project, per-org, or portable across projects?
+- Vouching: maintainers only, or any trusted contributor?
+- Score decay: does dormancy reduce a score over time?
+- Transparency: do contributors see their score? Can they dispute events?

--- a/docs/gastown-casehub-analysis-v2.md
+++ b/docs/gastown-casehub-analysis-v2.md
@@ -1,7 +1,7 @@
 # CaseHub vs Gastown: Architectural Analysis
 
-> **Status:** Working document — updated 2026-05-02
-> **Date:** 2026-04-27 (last revised 2026-05-02)
+> **Status:** Working document — updated 2026-05-25
+> **Date:** 2026-04-27 (last revised 2026-05-25)
 > **Version:** v2 — full rewrite with foundation/application separation
 
 ---
@@ -416,22 +416,27 @@ Gastown's application-layer capabilities are tightly integrated with its infrast
 
 These capabilities are operational and battle-tested at v1.0.1. For the software engineering domain, this is a complete application.
 
-### 5.2 What casehub-devtown Would Provide
+### 5.2 What casehub-devtown Provides
 
-`casehub-devtown` is a planned separate repo — not a module in `casehub-engine`. The foundation provides the primitives; the application wires them for the domain:
+`casehub-devtown` is an active separate repo — not a module in `casehub-engine`. The foundation provides the primitives; the application wires them for the domain. Multiple tutorial layers have shipped as of 2026-05-25:
 
-| Application capability | CaseHub primitive used |
-|-----------------------|----------------------|
-| Merge queue as a process | `CasePlanModel` — each case is a batch of MRs |
-| MR human review gate | `WorkItem` with SLA + form schema + escalation policy |
-| CI / lint / security check | Lambda worker or Quarkus Flow workflow worker |
-| Batch-then-bisect strategy | Choreography binding: tip-of-batch fails → binding condition routes to bisect sub-case |
-| Agent-to-agent review communication | qhorus typed channels (COMMAND, RESPONSE, DONE, FAILURE) |
-| Failure notification | casehub-connectors Slack/Teams delivery |
-| Commitment tracking per MR | qhorus 7-state Commitment lifecycle |
-| Audit trail per merge decision | Merkle ledger entry with W3C PROV-DM lineage |
+| Application capability | CaseHub primitive used | Status |
+|-----------------------|----------------------|--------|
+| Content-driven PR routing | `CasePlanModel` — security review fires on code content, not author labels | ✅ Layer 5 (devtown#10) |
+| MR human review gate with SLA | `WorkItem` with SLA + escalation via `SlaBreachPolicy` SPI | ✅ Layer 2 (devtown#41) |
+| Human + CI parallel execution | WAITING state — both fire simultaneously, total time = max not sum | ✅ Layer 5 (devtown#10) |
+| HITL case resumption (happy path) | `casehub-work-adapter` wired; `WorkItemLifecycleEvent(COMPLETED)` → case signal | ✅ devtown#33 |
+| Cryptographic audit per case event | `CaseLedgerEntry` Merkle ledger entry | ✅ P1.4 (engine) |
+| SLA breach → failure goal | `CasePlanModel` failure goal (kind: failure) | ⚠️ engine#326 open |
+| Merge queue as a process | `CasePlanModel` — each case is a batch of MRs | Not started |
+| Batch-then-bisect strategy | Choreography binding: tip-of-batch fails → bisect sub-case | Not started |
+| Agent-to-agent review communication | qhorus typed channels (COMMAND, RESPONSE, DONE, FAILURE) | Layer 3 (upcoming) |
+| Failure notification | casehub-connectors Slack/Teams delivery | Not started |
+| Trust-weighted reviewer assignment | `TrustWeightedSelectionStrategy` | ⚠️ P1.3 pending |
+| Commitment tracking per MR | qhorus 7-state Commitment lifecycle | ⚠️ P1.3 + qhorus#199 |
+| Cross-deployment reputation | ledger `TrustExportService` / `TrustImportService` | ✅ P2.1 (ledger, inherited) |
 
-`casehub-devtown` does not exist yet. Gastown's Refinery is in production. This is the most significant application-layer gap.
+Gastown's Refinery is in production at v1.0.1. devtown is pre-production and actively building toward feature parity with architectural improvements Gastown cannot provide structurally. The most significant remaining gap is merge queue (Bors-style batch-then-bisect) and operational tooling equivalent to Gastown's `gt` CLI.
 
 ### 5.3 What casehub-devtown Would Add That Gastown Cannot
 
@@ -548,7 +553,7 @@ These are direct infrastructure advantages — not minimised, not framed as futu
 
 **Single source of truth.** Everything flows through one Dolt server per town. There are no cross-repo coherence gaps of the kind CaseHub's platform audit documents (findings #1, #2, #4, #5, #7). CaseHub's distributed, SPI-pluggable persistence model is architecturally superior for extensibility and compliance, but it creates integration gaps by design. Gastown avoids them by design.
 
-**Cross-deployment reputation.** Wasteland stamps are federated via DoltHub, production-ready, and portable across organizations. CaseHub's TrustExportService/TrustImportService is planned.
+**Cross-deployment reputation.** Wasteland stamps are federated via DoltHub, production-ready, and portable across organizations. CaseHub's `TrustExportService` / `TrustImportService` SPI shipped (ledger#63–65, 2026-05-14 — P2.1 closed). Structural parity achieved. Key distinction: CaseHub's trust is derived from cryptographically attested outcomes, not human-curated stamps.
 
 ---
 
@@ -589,17 +594,13 @@ Wiring issues in the existing design. Not new features — completion of designe
 
 **Closed:** `LedgerWriteService.record()` now writes `LedgerAttestation` on DONE (SOUND, 0.7), FAILURE (FLAGGED, 0.6), DECLINE (FLAGGED, 0.4). Confidence values config-driven via `casehub.ledger.attestations.*`. 899 tests passing. Commit `17556e0`.
 
-#### P0.3 — Actor identity fragmentation ([ledger#47](https://github.com/casehubio/ledger/issues/47), [qhorus#124](https://github.com/casehubio/qhorus/issues/124))
+#### ~~P0.3 — Actor identity fragmentation ([ledger#47](https://github.com/casehubio/ledger/issues/47), [qhorus#124](https://github.com/casehubio/qhorus/issues/124))~~ ✅ FULLY DONE 2026-05-03
 
-**Symptom:** Every new Claude session starts with zero trust, even if the same AI persona has built a strong track record. EigenTrust computes over session IDs, not personas.
+~~**Symptom:** Every new Claude session starts with zero trust, even if the same AI persona has built a strong track record. EigenTrust computes over session IDs, not personas.~~
 
-**Root cause:** Qhorus `LedgerWriteService` writes `actorId = message.sender` (raw instance ID like `claudony-worker-abc123`). Persona format (`claude:analyst@v1`) never reaches the ledger from Qhorus interactions.
+**Closed:** All four consumers updated to `ActorTypeResolver.resolve()` (2026-04-29). `InstanceActorIdProvider` SPI + `DefaultInstanceActorIdProvider` shipped (2026-04-29). **claudony-casehub implementation:** `ClaudonyInstanceActorIdProvider` (`@Alternative @Priority(1)`) maps `claudony-worker-{uuid}` → `claude:{roleName}@v1` via reverse lookup in `WorkerSessionMapping` (claudony#107, closed 2026-05-03). Trust now accumulates per persona across sessions. The normative→trust closed feedback loop is end-to-end active.
 
-~~**Fix 1:** Add `ActorTypeResolver` utility to casehub-ledger — single canonical `actorId` derivation for all consumers. ([ledger#47](https://github.com/casehubio/ledger/issues/47))~~ **✅ DONE 2026-04-28** — utility created. **Consumer updates ✅ DONE 2026-04-29** — casehub-qhorus (`3cb5749`), casehub-work (`dcad49b`), claudony (`434d7df`) all now use `ActorTypeResolver.resolve()`. All four consumers complete.
-
-~~**Fix 2:** Add `InstanceActorIdProvider` SPI to casehub-qhorus — maps Qhorus instance IDs to ledger persona IDs. claudony-casehub implements it. ([qhorus#124](https://github.com/casehubio/qhorus/issues/124)) — *pending*~~ **✅ SPI DONE 2026-04-29** — `InstanceActorIdProvider` + `DefaultInstanceActorIdProvider` (no-op identity) shipped. `CommitmentAttestationPolicy` SPI also shipped. claudony-casehub session→persona mapping implementation still pending — trust accumulation per persona not yet active (qhorus#124 open).
-
-**Repos:** casehub-ledger, casehub-qhorus, claudony-casehub
+**Repos:** casehub-ledger ✅, casehub-qhorus ✅, claudony-casehub ✅
 
 ### P1 — Breaks at Scale (10+ Concurrent Cases / Agents)
 
@@ -613,10 +614,10 @@ New capabilities, but hard blockers before CaseHub can operate at meaningful age
 | **#54 — TrustGateService** | ✅ DONE | `TrustGateService` CDI bean: `meetsThreshold(actorId, minTrust)` Phase 1 shipped. Phase 2 (capability-scoped) ready for wiring once #61 completes. |
 | **#53 — ActorTypeResolver consumers** | ✅ DONE | All three consumers updated (see P0.3 above). |
 | **Attestation confidence** | ✅ DONE (bonus) | Bayesian Beta score now incorporates attestation confidence values, not just verdict polarity. |
-| #56 — Ledger health checks | Pending | |
-| #57 — Multi-attestation aggregation | Pending | |
-| #58 — Compliance report API | Pending | |
-| #59 — ProvenanceSupplement enricher | Pending (needs #67 ✅) | |
+| ~~#56 — Ledger health checks~~ | ✅ DONE 2026-05-05 | `LedgerHealthJob` + `LedgerReconciliationSource` SPI + `LedgerGapDetected` CDI event |
+| ~~#57 — Multi-attestation aggregation~~ | ✅ DONE 2026-05-05 | `AttestationAggregator` with `WEIGHTED_MAJORITY`, `UNANIMOUS_REQUIRED`, `FIRST_ATTESTOR` strategies |
+| ~~#58 — Compliance report API~~ | ✅ DONE 2026-05-05 | `LedgerComplianceReportService` — `JSON_LD`, `CSV`, `PLAIN_JSON`; Merkle root anchor |
+| ~~#59 — ProvenanceSupplement enricher~~ | ✅ DONE 2026-05-05 | `@ProvenanceCapture` CDI interceptor + `ProvenanceContext @RequestScoped` + `@PrePersist` listener |
 
 ---
 
@@ -690,13 +691,13 @@ Gate via `@IfBuildProperty("casehub.ledger.backend", "postgresql")` / `@UnlessBu
 
 ### P2 — Production Quality
 
-#### P2.1 — Cross-deployment trust federation
+#### ~~P2.1 — Cross-deployment trust federation~~ ✅ DONE 2026-05-14
 
-**Symptom:** Trust built by an agent in one CaseHub deployment is invisible to another.
+~~**Symptom:** Trust built by an agent in one CaseHub deployment is invisible to another.~~
 
-**Fix:** Add to casehub-ledger: `TrustExportService` (publishes `ActorTrustScore` deltas in canonical format) and `TrustImportService` SPI (consumes trust deltas from external source, seeds Bayesian priors). Seeding Beta(α, β) from an external source rather than Beta(1,1) is a one-line change in `TrustScoreJob`. The work is the data exchange format and transport.
+**Closed:** `TrustExportService` (canonical trust delta format, export endpoint behind config flag) and `TrustImportService` SPI (seeds Beta(α,β) from external source) both shipped in casehub-ledger (ledger#63, #64, #65). Trust bootstrapping from prior deployment on first registration: ledger#65. This closes the P2.1 gap and gives CaseHub structural parity with Gastown's Wasteland federation. Key distinction: CaseHub's exported trust is derived from cryptographically attested commitment outcomes, not human-curated stamps.
 
-**Repos:** casehub-ledger
+**Repos:** casehub-ledger ✅
 
 #### ~~P2.2 — OTel trace alignment ([engine#185](https://github.com/casehubio/engine/issues/185))~~ ✅ DONE 2026-04-28
 
@@ -744,9 +745,9 @@ Gate via `@IfBuildProperty("casehub.ledger.backend", "postgresql")` / `@UnlessBu
 
 | Phase | Items | Gate to next phase |
 |-------|-------|-------------------|
-| **P0 — Wiring** | ~~ledger#47~~ ✅ ~~qhorus#123~~ ✅ ~~qhorus#124 SPI~~ ✅ ~~engine#186 engine-side~~ ✅ · **qhorus#124 claudony persona mapping open** | Normative layer functional end-to-end; trust accumulates from real behaviour |
-| **P1 — Scale** | Concurrency throttle, RecoveryPolicy SPI, trust routing wired · ~~CaseLedgerEntry merged~~ ✅ · Doltgres backend (P1.5) | Can run 10+ agents; trust actually drives routing; time-travel + branching available |
-| **P2 — Quality** | ~~OTel alignment~~ ✅ · causal chain (partial ✅) · trust federation | Full observability; audit trail complete; cross-deployment trust |
+| **P0 — Wiring** | ~~ledger#47~~ ✅ ~~qhorus#123~~ ✅ ~~qhorus#124 SPI~~ ✅ ~~engine#186 engine-side~~ ✅ ~~claudony#107 persona mapping~~ ✅ · **P0 COMPLETE** | Normative layer functional end-to-end; trust accumulates from real behaviour ✅ |
+| **P1 — Scale** | Concurrency throttle ⚠️ · RecoveryPolicy SPI ⚠️ · trust routing wired (engine#336+#337+qhorus#199) ⚠️ · ~~CaseLedgerEntry merged~~ ✅ · Doltgres backend (P1.5) ⚠️ | Can run 10+ agents; trust actually drives routing; time-travel + branching available |
+| **P2 — Quality** | ~~OTel alignment~~ ✅ · causal chain (partial ✅, provisioner wiring pending claudony#94) · ~~trust federation~~ ✅ | Full observability; audit trail complete; cross-deployment trust |
 
 ---
 
@@ -758,16 +759,20 @@ Application work is distinct from foundation work. These items are built on top 
 
 `casehub-devtown` is a separate repo — not a module in casehub-engine. The foundation knows nothing about git, PRs, or CI; the application provides all domain logic.
 
-| Application capability | CaseHub primitive | Foundation gate |
-|-----------------------|------------------|----------------|
-| Merge queue as a process | `CasePlanModel` per batch of MRs | P0 complete |
-| MR human review gate | `WorkItem` with SLA + form schema | P1 complete |
-| CI / lint / security check | Lambda or Quarkus Flow workflow worker | P0 complete |
-| Batch-then-bisect strategy | Choreography binding: tip-of-batch fails → binding routes to bisect sub-case | P0 complete |
-| Agent-to-agent review | qhorus typed channels (COMMAND/RESPONSE/DONE/FAILURE) | P0 complete |
-| Failure notifications | casehub-connectors Slack/Teams delivery | A2 complete |
-| Trust-weighted reviewer assignment | TrustWeightedSelectionStrategy | P1 complete |
-| Cryptographic merge audit | Merkle ledger entry, CaseLedgerEntry | P1 complete |
+| Application capability | CaseHub primitive | Foundation gate | devtown status |
+|-----------------------|------------------|----------------|----------------|
+| Content-driven PR routing | `CasePlanModel` — bindings gate on code content | P0 ✅ | ✅ Layer 5 (devtown#10) |
+| MR human review gate with SLA | `WorkItem` + `SlaBreachPolicy` SPI | P0 ✅ | ✅ Layer 2 (devtown#41) |
+| CI / lint / security check | Lambda binding worker | P0 ✅ | ✅ Layer 5 (devtown#10) |
+| HITL case resumption (happy path) | `casehub-work-adapter` wired | P0 ✅ | ✅ devtown#33 |
+| Cryptographic audit per case event | `CaseLedgerEntry`, Merkle ledger | P1.4 ✅ | ✅ Inherited from foundation |
+| Cross-deployment reputation | `TrustExportService` / `TrustImportService` | P2.1 ✅ | ✅ Inherited from foundation |
+| SLA breach → case failure goal | CasePlanModel `kind: failure` | ✅ (pending engine#326) | ⚠️ engine#326 open |
+| Agent-to-agent review | qhorus typed channels (COMMAND/RESPONSE/DONE/FAILURE) | P0 ✅ | Layer 3 (upcoming) |
+| Trust-weighted reviewer assignment | `TrustWeightedSelectionStrategy` | P1.3 ⚠️ | ⚠️ P1.3 pending |
+| Merge queue as a process | `CasePlanModel` per batch of MRs | P0 ✅ | Not started |
+| Batch-then-bisect strategy | Choreography binding: tip-of-batch fails → bisect sub-case | P0 ✅ | Not started |
+| Failure notifications | casehub-connectors Slack/Teams delivery | parent#5 ⚠️ | Not started |
 
 This establishes the application layer pattern for any future domain applications. The pattern is always the same: separate repo, foundation primitives, domain logic, no changes to the foundation. The foundation does not know or care what domain is above it.
 
@@ -775,13 +780,13 @@ This establishes the application layer pattern for any future domain application
 
 These capabilities are needed by every application domain but are implemented at the adapter/integration layer, not in the foundation itself.
 
-**SLA propagation ([parent#6](https://github.com/casehubio/parent/issues/6)):** Case budget bounds child WorkItem and Commitment deadlines. Currently a 1-hour case can spawn a 48-hour WorkItem. Fix in `casehub-work-adapter`.
+**~~SLA propagation ([parent#6](https://github.com/casehubio/parent/issues/6))~~** ✅ DONE 2026-05-20 — Engine-side: `HumanTaskScheduleHandler` applies `min(taskDeadline, caseBudgetDeadline)` from `PropagationContext.caseBudgetDeadline`. Claudony Commitment deadline bounding still deferred (no COMMAND-creation code yet in claudony).
 
-**Notification consolidation ([parent#5](https://github.com/casehubio/parent/issues/5)):** `casehub-work-notifications` Slack/Teams implementations replaced with `casehub-connectors` delegation. Unblocks unified delivery for stalled commitment alerts, case fault notifications, and escalation notifications.
+**Notification consolidation ([parent#5](https://github.com/casehubio/parent/issues/5)):** ⚠️ PENDING — `casehub-work-notifications` Slack/Teams implementations replaced with `casehub-connectors` delegation. No progress since filed. Blocking: qhorus#200 `WatchdogAlertEvent + ConnectorAlertBridge` cannot be wired until parent#5 provides a consolidated `Connector` SPI.
 
-**Critical event notifications:** Wire three event sources to casehub-connectors: `WatchdogEvaluationService` stall detection, `CaseLifecycleEvent(FAULTED)`, and `EscalationPolicy.escalate()` in casehub-work. Depends on notification consolidation completing first.
+**Critical event notifications:** Wire three event sources to casehub-connectors: `WatchdogEvaluationService` stall detection, `CaseLifecycleEvent(FAULTED)`, and SLA breach escalation in casehub-work. Depends on parent#5 completing first.
 
-**Human-in-the-loop end-to-end:** Complete `casehub-work-adapter` so that `WorkItemLifecycleEvent(COMPLETED)` with a `callerRef` encoding `case:{id}/pi:{planItemId}` fires `CaseHubReactor.signal()`, transitioning the plan item from WAITING to active and triggering binding re-evaluation. Without this, CaseHub cannot orchestrate any process requiring human judgment mid-case.
+**~~Human-in-the-loop end-to-end (happy path)~~** ✅ DONE 2026-05-23 — `casehub-work-adapter` wired (devtown#33); `WorkItemLifecycleEvent(COMPLETED)` → `CaseHubReactor.signal()` → plan item WAITING → active (devtown#30 e2e test passing). **Remaining gap:** escalation-during-wait signal path — when a WorkItem escalates (SLA breach), `ExpiryLifecycleService` does not signal the engine, leaving WAITING plan items frozen (work#225, blocked on engine#349 `CaseSignalSink` SPI).
 
 ### A3 — Other Planned Application Domains
 
@@ -804,11 +809,11 @@ Individual issues exist for the top 8:
 | ~~1~~ | ~~Commitment terminal states don't write LedgerAttestation — trust scoring has no normative signal~~ **✅ DONE 2026-04-28** | qhorus, ledger | [qhorus#123](https://github.com/casehubio/qhorus/issues/123) | ~~P0.2~~ |
 | ~~2~~ | ~~ActorType derivation uses 4 different logics — same actor gets different ActorType across repos.~~ **✅ DONE 2026-04-29** — `ActorTypeResolver` utility shipped; all consumers (qhorus `3cb5749`, work `dcad49b`, claudony `434d7df`, engine) updated. | ledger, work, qhorus, engine | [ledger#47](https://github.com/casehubio/ledger/issues/47) | ~~P0.3~~ |
 | 3 | Two parallel delivery SPIs (casehub-connectors + casehub-work-notifications) with overlapping Slack/Teams | connectors, work | [parent#5](https://github.com/casehubio/parent/issues/5) | A2 |
-| 4 | Qhorus instanceId and ledger actorId unjoined — trust doesn't accumulate across sessions of same persona | qhorus, ledger, claudony | [qhorus#124](https://github.com/casehubio/qhorus/issues/124) | P0.3 |
+| ~~4~~ | ~~Qhorus instanceId and ledger actorId unjoined — trust doesn't accumulate across sessions of same persona~~ **✅ DONE 2026-05-03** — `ClaudonyInstanceActorIdProvider` (claudony#107) maps session IDs to persona format. Trust now accumulates per persona. | qhorus, ledger, claudony | [qhorus#124](https://github.com/casehubio/qhorus/issues/124) | ~~P0.3~~ |
 | 5 | Cross-repo causal chain broken — no causedByEntryId linking MessageLedgerEntry → CaseLedgerEntry → WorkItemLedgerEntry | claudony, engine, qhorus | [claudony#94](https://github.com/casehubio/claudony/issues/94) | P2.3 |
 | ~~6~~ | ~~PropagationContext.traceId is UUID, OTel trace ID is W3C hex — case spans not correlatable in Jaeger~~ **✅ DONE 2026-04-28** | engine, ledger | [engine#185](https://github.com/casehubio/engine/issues/185) | ~~P2.2~~ |
-| 7 | CaseHub work assignments don't create Qhorus COMMITMENTs — normative obligation lifecycle bypassed entirely. **Partial ✅ 2026-05-01** — engine side done (engine#186 closed); claudony persona→session mapping (qhorus#124) still open. | engine, qhorus, claudony | [engine#186](https://github.com/casehubio/engine/issues/186) | P0.1 |
-| 8 | No SLA propagation from case budget to child WorkItems or Commitments | engine, work, qhorus | [parent#6](https://github.com/casehubio/parent/issues/6) | A2 |
+| ~~7~~ | ~~CaseHub work assignments don't create Qhorus COMMITMENTs — normative obligation lifecycle bypassed entirely.~~ **✅ DONE 2026-05-03** — engine#186 closed 2026-05-01; claudony persona→session mapping (claudony#107) closed 2026-05-03. Full normative loop active. | engine, qhorus, claudony | [engine#186](https://github.com/casehubio/engine/issues/186) | ~~P0.1~~ |
+| ~~8~~ | ~~No SLA propagation from case budget to child WorkItems or Commitments~~ **✅ DONE 2026-05-20** — engine-side fix: `HumanTaskScheduleHandler` applies `min(taskDeadline, caseBudgetDeadline)`. Claudony Commitment deadline bounding still deferred. | engine, work, qhorus | [parent#6](https://github.com/casehubio/parent/issues/6) | ~~A2~~ |
 
 Four structural themes run through all 32 findings:
 
@@ -862,6 +867,10 @@ Tracks design decisions that produce capabilities Gastown structurally cannot ma
 | DT-003 | Trust dimensions grounded in normative layer — `REVIEW_THOROUGHNESS`, `FALSE_POSITIVE_RATE`, `SCOPE_CALIBRATION` | ✅ Implemented — Epic 2 |
 | DT-004 | Routing thresholds as configurable `RoutingPolicy` artifacts, not hard-coded constants | ✅ Implemented — Epic 2 |
 | DT-005 | `RoutingPolicy` with uncertainty handling — `borderlineMargin` triggers `HumanOversight`; `minimumObservations` credibility gate; `rationale` for audit | ✅ Implemented — Epic 2 |
-| DT-006 | Trust maturity model — four automatic phases (bootstrap→emerging→active→adaptive); degradation guarantee; platform pattern (parent#14) | ✅ Implemented — Epic 2 |
+| DT-006 | Trust maturity model — four automatic phases (bootstrap→emerging→active→adaptive); degradation guarantee; platform pattern (parent#14 closed 2026-05-21) | ✅ Implemented — Epic 2 |
+| DT-007 | Layer 2: SLA-bounded human review gate with two-tier escalation — first breach rotates candidateGroups, second breach signals case context; built on `SlaBreachPolicy` SPI | ✅ Implemented — devtown#41, devtown#42 |
+| DT-008 | Content-driven binding routing — security review fires on code content, not author labels; multiple checks fire in parallel without explicit declaration; human + CI in parallel via WAITING state | ✅ Implemented — devtown#10 (Epic 3) |
+| DT-009 | Ed25519 bilateral agent signing — platform signs COMMAND, agent signs RESPONSE; neither can repudiate; compromise detection via CDI event; post-quantum migration path ADR; inherited by all domain apps | ✅ Implemented — ledger#79, #80, #83, #84 |
+| DT-010 | Trust federation across deployments — `TrustExportService` + `TrustImportService` SPI; cross-deployment Beta(α,β) seeding; mathematically-derived trust vs Gastown's human-curated stamps | ✅ Implemented — ledger#63, #64, #65 (P2.1 closed) |
 
 Full entries with reasoning and foundation gate dependencies: [`docs/PROGRESS.md`](PROGRESS.md)

--- a/docs/protocols/casehub/cross-repo-design-doc-state-verification.md
+++ b/docs/protocols/casehub/cross-repo-design-doc-state-verification.md
@@ -1,0 +1,14 @@
+---
+id: PP-20260522-fe93b6
+title: "Verify peer-repo state before citing it as fact in a design document"
+type: rule
+scope: platform
+applies_to: "all casehubio design documents and specs that reference symbols, methods, or commits in peer repos"
+severity: important
+refs:
+  - casehub/HARNESS-INDEX.md
+violation_hint: "Design doc states a symbol, method, or commit 'is already committed', 'ships in', or 'is available in' a peer repo without a verification step — Path.root() was described as 'already committed to platform main' when it existed in none of the platform branches (GE-20260522-9cd6d5)"
+created: 2026-05-22
+---
+
+Before citing a peer repo's state as fact — a method exists, a feature shipped, a commit landed — verify it with `git -C <repo> grep <symbol> HEAD` or by reading the file. Aspirational or planned state must be marked explicitly: 'planned', 'to be committed', or 'blocked on <issue>'. Unverified claims in design documents become compile blockers discovered only during implementation review, when fixing them requires cross-session coordination.

--- a/docs/protocols/casehub/hitl-test-context-pre-seeding.md
+++ b/docs/protocols/casehub/hitl-test-context-pre-seeding.md
@@ -1,0 +1,15 @@
+---
+id: PP-20260521-134c38
+title: "Pre-seed parallel check keys with non-null values in HITL integration tests"
+type: rule
+scope: application
+applies_to: "@QuarkusTest classes exercising humanTask bindings in devtown CasePlanModels"
+severity: important
+refs:
+  - casehub/hitl-runtime-assembly.md
+  - casehub/yaml-humantask-binding-type.md
+violation_hint: "Missing non-null values for styleCheck/testCoverage/performanceAnalysis/ci causes those capability bindings to fire, triggering tryProvision() calls that block the Vert.x event loop and prevent WorkItemLifecycleAdapter from completing its context update within the 5-second timeout"
+created: 2026-05-21
+---
+
+In HITL @QuarkusTest integration tests, the initial case context must include non-null values for all parallel check keys (styleCheck, testCoverage, performanceAnalysis, ci) whose bindings would otherwise fire and call tryProvision(). The values must be non-APPROVED (e.g. `{outcome: "PENDING"}`) to keep the pr-approved goal unsatisfied while the humanTask WorkItem lifecycle plays out. This prevents capability binding churn on the Vert.x event loop — churn that causes the WorkItemLifecycleAdapter to time out before it can apply the outputMapping and fire CONTEXT_CHANGED. See GE-20260521-9188c1: YAML when: conditions are not evaluated at runtime, so all contextChange bindings fire unconditionally.

--- a/docs/protocols/casehub/transactional-loop-control-flow-exceptions.md
+++ b/docs/protocols/casehub/transactional-loop-control-flow-exceptions.md
@@ -1,0 +1,14 @@
+---
+id: PP-20260522-f08b62
+title: "Control-flow exceptions in @Transactional item loops must not escape the loop boundary"
+type: rule
+scope: application
+applies_to: "@Transactional service methods in casehub-work (and devtown) that iterate over WorkItems or domain entities and use private RuntimeExceptions for internal control flow"
+severity: critical
+refs:
+  - casehub/HARNESS-INDEX.md
+violation_hint: "Private RuntimeException (e.g. BreachExecutionFailed) thrown inside executeBreachDecision() for a control-flow case (EscalateTo empty groups) is only caught by one branch (Chained) — if the top-level dispatch receives the triggering input directly, the exception escapes to the @Transactional boundary, rolls back all items processed in that tick, and causes silent infinite retry (GE-20260522-4e806e)"
+created: 2026-05-22
+---
+
+Any private RuntimeException used as a control-flow mechanism (as opposed to a genuine error) inside a helper called from a `@Transactional` loop must be caught before it can escape the loop body. The fix is two-layered: (1) validate eagerly at the factory or input site to prevent the triggering condition from being created, and (2) add a catch at the top-level dispatch within the loop to apply a safe fallback if the exception still escapes. A transaction rollback caused by an escaped control-flow exception leaves every item in the batch un-processed, produces no audit entry, and triggers re-processing on every subsequent scheduler tick — with no log evidence at the point of failure.

--- a/docs/protocols/casehub/work-adapter-memory-plan-item-store.md
+++ b/docs/protocols/casehub/work-adapter-memory-plan-item-store.md
@@ -1,0 +1,15 @@
+---
+id: PP-20260521-a36692
+title: "MemoryPlanItemStore must be in selected-alternatives when casehub-engine-work-adapter is on the test classpath"
+type: rule
+scope: application
+applies_to: "app/src/test/resources/application.properties — any devtown @QuarkusTest module that indexes casehub-engine-work-adapter"
+severity: important
+refs:
+  - casehub/hitl-runtime-assembly.md
+  - casehub/work-adapter-test-subcase-group-repository.md
+violation_hint: "WorkAdapterPlanItemEntity (from the work-adapter jar) is not in the default persistence unit. Without MemoryPlanItemStore, HumanTaskScheduleHandler.handleInlineMode() calls planItemStore.save() which throws on the JPA entity, rolls back the transaction, and the WorkItem is never committed — appearing in logs but absent from the DB"
+created: 2026-05-21
+---
+
+When `casehub-engine-work-adapter` is indexed via `quarkus.index-dependency`, its `WorkAdapterPlanItemEntity` is visible to Hibernate but not mapped to any persistence unit. `HumanTaskScheduleHandler.handleInlineMode()` calls `planItemStore.save()` — if the JPA `PlanItemStore` implementation is active, this throws an `IllegalArgumentException` that silently rolls back the handler's `@Transactional` boundary, undoing the WorkItem creation. Add `io.casehub.persistence.memory.MemoryPlanItemStore` to `quarkus.arc.selected-alternatives` in `src/test/resources/application.properties` (without `%test.` prefix — this is a build-time property). See PP-20260514-d69243 for the parallel SubCaseGroupRepository rule.

--- a/docs/specs/2026-05-07-epic1-scaffold-design.md
+++ b/docs/specs/2026-05-07-epic1-scaffold-design.md
@@ -1,0 +1,81 @@
+# Epic 1: Project Scaffold — Design Spec
+2026-05-07
+
+## Context
+
+`casehub-devtown` is the AI-assisted software development application on the CaseHub platform. This spec covers the Maven project structure, module boundaries, dependency graph, and CI/publish workflows that form the buildable skeleton — no application logic, just the structure everything else will be built into.
+
+Done when: `mvn clean install` succeeds with all foundation modules resolved from GitHub Packages.
+
+## Module Structure
+
+Five-module Maven multi-module layout. More modules early forces discipline — cleaner interfaces, stops domain logic bleeding across boundaries, makes it easier to combine than to split later.
+
+```
+casehub-devtown (parent pom, packaging=pom)
+├── devtown-domain      pure Java — capability tags, trust dimensions, routing thresholds
+├── devtown-review      PR review CasePlanModel, review bindings, trust-weighted routing logic
+├── devtown-queue       merge queue orchestration, batch-then-bisect
+├── devtown-github      GitHub boundary — webhook/polling receiver, CI status reader, merge executor
+└── devtown-app         Quarkus assembly — REST entry points, notification wiring, runtime deps
+```
+
+`trust` is a package within `devtown-review` (trust-weighted routing is inseparable from review routing decisions). `notify` is a package within `devtown-app` (notification wiring is application-level connector setup).
+
+## Dependency Graph
+
+| Module | Depends on |
+|--------|-----------|
+| `devtown-domain` | nothing — pure Java constants, no foundation deps |
+| `devtown-review` | `devtown-domain`, `casehub-engine-api`, `casehub-qhorus-api`, `casehub-ledger-api`, `casehub-work-api` |
+| `devtown-queue` | `devtown-domain`, `devtown-review`, `casehub-engine-api` |
+| `devtown-github` | `devtown-domain`, `devtown-review`, `devtown-queue`, `quarkus-rest-client`, `quarkus-rest-client-jackson` |
+| `devtown-app` | all above modules + runtime: `casehub-qhorus`, `casehub-ledger`, `casehub-work`, `casehub-connectors`, `quarkus-rest`, `quarkus-rest-jackson`, `quarkus-jdbc-h2`, `quarkus-smallrye-health` |
+
+All casehub artifacts are `0.2-SNAPSHOT` resolved from `https://maven.pkg.github.com/casehubio/*`. Parent POM coordinates: `io.casehub:casehub-parent:0.2-SNAPSHOT`.
+
+## POM Hierarchy
+
+Parent pom (`casehub-devtown`) inherits from `io.casehub:casehub-parent:0.2-SNAPSHOT` and imports the Quarkus platform BOM. It pins all casehub artifact versions via `<dependencyManagement>` using `${casehub.version}` = `0.2-SNAPSHOT`. Stack: Java 21 source/target (on Java 26 JVM at build time), Quarkus 3.32.2.
+
+Each child module inherits from the parent pom. No version declarations in child poms except for non-casehub, non-Quarkus deps not covered by either BOM.
+
+## Package Structure
+
+Each module owns one top-level package:
+
+| Module | Root package |
+|--------|-------------|
+| `devtown-domain` | `io.casehub.devtown.domain` |
+| `devtown-review` | `io.casehub.devtown.review` |
+| `devtown-queue` | `io.casehub.devtown.queue` |
+| `devtown-github` | `io.casehub.devtown.github` |
+| `devtown-app` | `io.casehub.devtown.app` |
+
+The scaffold creates the package directories with placeholder classes (one per module) sufficient for Maven to compile and Quarkus to boot. For `devtown-app` this means at minimum a `@QuarkusTest`-annotated empty test so that `mvn verify` exercises the Quarkus boot path.
+
+## Quarkus Application
+
+`devtown-app` is the only runnable module. It gets:
+- `src/main/java/io/casehub/devtown/app/DevtownApplication.java` — empty `@QuarkusMain` (or just rely on Quarkus auto-discovery; no explicit main needed unless customising startup)
+- `src/main/resources/application.properties` — skeleton with commented stubs for GitHub connection config, database config, and Quarkus HTTP port
+
+## GitHub Actions Workflows
+
+Two workflows, matching the claudony pattern:
+
+**`ci.yml`** — Build and test on every change:
+- Triggers: `push` to `main`, `pull_request` targeting `main`, `repository_dispatch: upstream-published`, `workflow_dispatch`
+- Java 21 / Temurin, `server-id: github` for GitHub Packages read
+- Runs: `mvn --batch-mode verify`
+- `GITHUB_TOKEN` passed for packages read
+
+**`publish.yml`** — Publish to GitHub Packages:
+- Triggers: `push` to `main`, `workflow_dispatch`
+- Same Java setup, `server-id: github`
+- Runs: `mvn --batch-mode deploy -DskipTests`
+- `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` for packages write (scoped to this repo)
+
+## Out of Scope
+
+This epic contains no application logic. No CasePlanModel YAML, no domain constants, no worker implementations — those belong to Epics 2 and 3. The placeholder classes exist only to satisfy the compiler.

--- a/docs/specs/2026-05-08-epic2-domain-model-design.md
+++ b/docs/specs/2026-05-08-epic2-domain-model-design.md
@@ -1,0 +1,407 @@
+# Epic 2: Domain Model Design Spec
+2026-05-08 (revised after design review)
+
+## Context
+
+`devtown-domain` is the authoritative source of the software engineering domain vocabulary for casehub-devtown. Everything in Epics 3–10 depends on this vocabulary. No foundation dependency — pure Java.
+
+This spec is the result of a systematic design review that challenged the original Gastown-derived vocabulary. The original 13 flat capability tags have been replaced with a typed, cohesive vocabulary that exploits the richer semantics of the CaseHub foundation.
+
+---
+
+## Platform Coherence
+
+**Step 1 — Already exists?**
+- `CapabilityTag.GLOBAL = "*"` in `casehub-ledger` is a sentinel — not a vocabulary. No overlap.
+- `LedgerAttestation.capabilityTag` and `TrustGateService.meetsThreshold(actorId, capabilityTag, minTrust)` consume string tags — devtown's constants are the domain-specific values that flow into those slots.
+- `ActorTrustScore.ScoreType.CAPABILITY` with `scope_key` and `ScoreType.DIMENSION` with `scope_key` — confirmed working; devtown's vocabulary values will flow directly into these.
+
+**Step 2 — Right repo?** Yes. Software engineering domain concepts (PR review, security analysis, merge operations) belong in the application tier.
+
+**Step 4 — Consistent with platform pattern?**
+- `public static final String` constants — matches `CapabilityTag` in ledger.
+- SPI in `domain.spi`, populated default in same module — matches engine's `NoOpWorkerProvisioner` pattern, refined: this is a **vocabulary/registry SPI** (not operational no-op), so the default is a populated implementation, not empty. PLATFORM.md updated to capture this distinction (parent#12).
+
+**Known gap:** `ScoreType.CAPABILITY_DIMENSION` (composite per-capability quality score) does not yet exist in the ledger. Tracked: ledger#76, devtown#19. Designed to accommodate it when it ships — no rework needed.
+
+---
+
+## Design Review: What Changed From the Original Spec
+
+The original spec had 13 flat capability tags copied from the Gastown vocabulary. After review:
+
+| Original | Disposition | Reason |
+|----------|------------|--------|
+| `code-analysis` through `performance-analysis` (6) | → `ReviewDomain` | These are analytical work types — typed separately because trust scoring, routing semantics, and actor type (AI agent) are homogeneous |
+| `ci-runner`, `merge-executor` (2) | → `AgentQualification` | Execution capabilities — trust scoring applies but semantics differ from analytical review |
+| `human-approval-gate` | → `HumanDecision` (elevated, renamed) | Not a routing constraint — a formal accountability event with its own lifecycle, SLA, and trust model |
+| `notify` | **Removed** | Connector call, not a trust-scored capability. `casehub-connectors` owns delivery; the case plan model calls it directly |
+| `batch-bisect`, `coordinated-merge`, `coordinated-rollback` | **Removed** | Orchestration operations — expressed as CasePlanModel binding structures (Epics 4/5). Names also challenged: devtown#20 tracks them |
+| *(new)* | → `HumanOversight` | Emerged from design: human called in when automated routing confidence is low — connects to `RoutingPolicy.borderlineMargin` and EU AI Act Art.12 |
+
+---
+
+## Types
+
+### 1. `ReviewDomain`
+
+What analytical work a PR needs. These strings also serve as `AgentQualification` values for the matching review type — an agent qualified for `security-review` handles PRs that need `security-review`. The string values flow into `LedgerAttestation.capabilityTag` and `TrustGateService`.
+
+```java
+public final class ReviewDomain {
+    public static final String CODE_ANALYSIS        = "code-analysis";
+    public static final String SECURITY_REVIEW      = "security-review";
+    public static final String ARCHITECTURE_REVIEW  = "architecture-review";
+    public static final String STYLE_REVIEW         = "style-review";
+    public static final String TEST_COVERAGE        = "test-coverage";
+    public static final String PERFORMANCE_ANALYSIS = "performance-analysis";
+    private ReviewDomain() {}
+}
+```
+
+### 2. `AgentQualification`
+
+Execution capabilities — things agents are qualified to execute, with trust scoring applied to outcome quality. Distinct from review domains: these are operational, not analytical.
+
+```java
+public final class AgentQualification {
+    public static final String CI_RUNNER      = "ci-runner";
+    public static final String MERGE_EXECUTOR = "merge-executor";
+    private AgentQualification() {}
+}
+```
+
+### 3. `HumanDecision`
+
+Formal accountability events requiring human judgment. Not a routing constraint — a first-class vocabulary type with dedicated actor type enforcement (`ActorType.HUMAN`), `casehub-work` WorkItem lifecycle (SLA, business hours, delegation, escalation), and trust accumulation on human actors.
+
+Naming: "decision" rather than "gate" or "approval" — a gate is something you pass through; a decision is a formal act by a named accountable person. GDPR Art.22 oversight requirement is met structurally.
+
+```java
+public final class HumanDecision {
+    public static final String PR_APPROVAL = "human-decision:pr-approval";
+    private HumanDecision() {}
+}
+```
+
+### 4. `HumanOversight`
+
+Human called in because the automated routing model is uncertain. Not a domain decision — a system-level check. Triggers when:
+- An agent's trust score is within `RoutingPolicy.borderlineMargin` of the threshold
+- No agent meets the minimum threshold for a required capability (fleet gap)
+- The trust model has too few observations (`minimumObservations` not reached — Beta prior not stabilised)
+- Multiple consecutive DECLINEs suggest a fleet capability gap
+
+This is EU AI Act Art.12 territory — human oversight when automated confidence is marginal. Gastown cannot provide this concept structurally because it has no trust model to be uncertain about.
+
+```java
+public final class HumanOversight {
+    public static final String ROUTING_REVIEW = "human-oversight:routing-review";
+    private HumanOversight() {}
+}
+```
+
+### 5. `DevtownTrustDimension`
+
+Quality dimension labels for `LedgerAttestation.trustDimension`. Three dimensions, all auto-computed from the normative layer.
+
+```java
+public final class DevtownTrustDimension {
+    public static final String REVIEW_THOROUGHNESS  = "review-thoroughness";
+    public static final String FALSE_POSITIVE_RATE  = "false-positive-rate";
+    public static final String SCOPE_CALIBRATION    = "scope-calibration";
+    private DevtownTrustDimension() {}
+}
+```
+
+**Why three, not four:**
+- `REVIEW_THOROUGHNESS` — recall: does the agent find issues that later cause incidents?
+- `FALSE_POSITIVE_RATE` — precision: does the agent flag things that weren't real problems?
+- `SCOPE_CALIBRATION` — normative: does the agent correctly DECLINE work outside its capability? Maps directly to the DECLINED commitment — only possible because CaseHub has formal speech acts. Gastown cannot measure this.
+
+**Why not `security-specialist`:** per-capability quality is expressed by combining `capabilityTag="security-review"` with `trustDimension="review-thoroughness"` on a single `LedgerAttestation`. This is how the ledger is designed to work. A separate `security-specialist` dimension would duplicate `ScoreType.CAPABILITY`. Once ledger#76 ships, the composite `CAPABILITY_DIMENSION` score type makes per-capability quality a first-class ledger concept.
+
+**Why not Gastown's `creativity`:** not auto-computable from normative layer events. If human attestors want to score it manually, the `DIMENSION` mechanism supports it without a declared constant.
+
+---
+
+## `RoutingPolicy`
+
+A value object replacing the original hard-coded thresholds. Policy artifacts are configurable per deployment, overridable per binding in the CasePlanModel, and auditable as case facts.
+
+```java
+public record RoutingPolicy(
+    OptionalDouble threshold,           // minimum trust to route to this capability
+    OptionalInt minimumObservations,    // trust score requires N attestations to be credible
+    OptionalDouble borderlineMargin,    // threshold ± margin → trigger HumanOversight
+    Optional<String> fallbackType,      // what to route to if no agent meets threshold
+    String rationale                    // why this threshold — captured for audit
+) {
+    public boolean isBootstrap(int agentObservations) {
+        return minimumObservations.isPresent()
+            && agentObservations < minimumObservations.getAsInt();
+    }
+
+    public boolean isBorderline(double trustScore) {
+        return borderlineMargin.isPresent() && threshold.isPresent()
+            && trustScore >= threshold.getAsDouble()
+            && trustScore < threshold.getAsDouble() + borderlineMargin.getAsDouble();
+    }
+}
+```
+
+**Field purposes:**
+- `threshold` — the minimum. Below this, never route.
+- `minimumObservations` — credibility gate. A score of 0.85 from 2 attestations is noise; from 50 it is signal. New agents route to lower-stakes work first.
+- `borderlineMargin` — the uncertainty band. Agents within this margin above threshold get a `HumanOversight` flag before assignment. Connects `RoutingPolicy` to `HumanOversight` vocabulary.
+- `fallbackType` — what to do when no agent qualifies: escalate to `HumanOversight`, route to a backup capability, hold. Policy-defined.
+- `rationale` — why does security-review have a 0.70 threshold? Captured as a string for audit records.
+
+---
+
+## `CapabilityRegistry` SPI
+
+Located in `io.casehub.devtown.domain.spi`. Pure Java — no CDI annotations.
+
+```java
+public interface CapabilityRegistry {
+    Set<String> capabilities();
+    Optional<RoutingPolicy> policy(String capability);
+    boolean isKnown(String capability);
+}
+```
+
+`policy()` returns `Optional<RoutingPolicy>` — richer than `OptionalDouble`. Not all capabilities have a routing policy (`code-analysis` has none — any agent capable of analysis is assigned). `isKnown()` allows validation without a separate lookup.
+
+---
+
+## `DevtownCapabilityRegistry`
+
+The populated default implementation — plain Java, no CDI annotations — in `io.casehub.devtown.domain`.
+
+Returns all capabilities across all four types, with routing policies for trust-sensitive ones:
+
+| Capability | Type | Threshold | Min observations | Borderline margin | Rationale |
+|-----------|------|-----------|-----------------|-------------------|-----------|
+| `code-analysis` | ReviewDomain | — | — | — | Any capable agent |
+| `security-review` | ReviewDomain | 0.70 | 10 | 0.05 | Security mistakes reach production; 10 obs = credible score |
+| `architecture-review` | ReviewDomain | 0.65 | 8 | 0.05 | Design mistakes are expensive to reverse |
+| `style-review` | ReviewDomain | 0.50 | 5 | — | Baseline; borderline not worth oversight overhead |
+| `test-coverage` | ReviewDomain | — | — | — | Any capable agent |
+| `performance-analysis` | ReviewDomain | — | — | — | Any capable agent |
+| `ci-runner` | AgentQualification | — | — | — | Deterministic — pass/fail is self-evident |
+| `merge-executor` | AgentQualification | 0.80 | 15 | 0.05 | Merge is irreversible; needs substantial history |
+| `human-decision:pr-approval` | HumanDecision | — | — | — | Human actor routing; threshold not applicable |
+| `human-oversight:routing-review` | HumanOversight | — | — | — | Triggered by borderlineMargin on other capabilities |
+
+`capabilities()` returns an immutable set of all capability strings. `policy()` returns the `RoutingPolicy` for trust-sensitive capabilities, `Optional.empty()` for others. `isKnown()` delegates to `capabilities().contains(capability)`.
+
+`policy(null)` throws `NullPointerException("capability must not be null")`.
+
+---
+
+## Trust Maturity Model
+
+The routing architecture is designed for a fleet with trust history. A new deployment has none. Without an explicit maturity model, trust-based routing either blocks all work (no agent meets threshold) or is silently bypassed (threshold set to zero). Neither is acceptable.
+
+This section defines how the system behaves across four phases of maturity, how transitions happen automatically, and what `RoutingPolicy` governs each phase.
+
+### The four phases
+
+**Phase 0 — Bootstrap (no trust history)**
+
+All agents are new. Bayesian Beta priors are at `(1,1)` — uniform, 0.5 trust for everyone. No meaningful signal exists.
+
+Routing behaviour: availability-based. Any agent capable of the work is eligible. Identical to Gastown's GUPP model. The system gets work done and accumulates the first attestations.
+
+`RoutingPolicy` fields active: none. `minimumObservations` gate suspends threshold enforcement. `borderlineMargin` not configured. `HumanOversight` triggered only for fleet-gap conditions (no agent capable of the work at all), not for borderline scores.
+
+Exit condition: any agent for this capability exceeds `minimumObservations` — threshold enforcement activates for that agent automatically.
+
+**Phase 1 — Emerging trust (sparse data)**
+
+Some agents have history. Trust scores are starting to differentiate. New agents still in bootstrap.
+
+Routing behaviour: threshold active for agents with sufficient history; availability routing for agents without. New agents are routed to lower-stakes capabilities first — `style-review` before `security-review`. The `minimumObservations` gate prevents a new agent's first-few-attestation score from being treated as reliable signal.
+
+`RoutingPolicy` fields active: `threshold`, `minimumObservations`, `fallbackType` (if no agent meets threshold: fall back to human or hold, never silently route below threshold). `borderlineMargin` not configured.
+
+Exit condition: most required capabilities have multiple agents with sufficient history, allowing meaningful comparison.
+
+**Phase 2 — Active trust routing (mature data)**
+
+Most agents have meaningful histories. Trust scores reliably differentiate. Routing quality is improving automatically from outcomes.
+
+Routing behaviour: full threshold enforcement. `borderlineMargin` activates — agents within margin trigger `HumanOversight` for spot-checking before assignment. `SCOPE_CALIBRATION` dimension accumulating signal from DECLINED commitments (only meaningful once agents are making genuine capability judgements).
+
+`RoutingPolicy` fields active: all of them. `isBorderline()` logic in use.
+
+Exit condition: steady state. Routing quality compounds as each outcome produces new attestations.
+
+**Phase 3 — Adaptive quality routing (rich data)**
+
+Long-running fleet. Per-capability quality dimensions (CAPABILITY_DIMENSION, ledger#76) are meaningful. An agent's `security-review` thoroughness is reliably distinct from their `architecture-review` thoroughness.
+
+Routing behaviour: quality floors per capability active alongside binary trust threshold. `HumanOversight` is primarily a compliance spot-check mechanism, not a gap-filler.
+
+`RoutingPolicy` fields active: extended to include per-capability quality floors once ledger#76 ships (additive, no rework).
+
+### Phase transition mechanism
+
+Transitions are **automatic** — no operator configuration change required. The `RoutingPolicy.minimumObservations` field is the single gate:
+
+```
+agent.observationCount < policy.minimumObservations  →  bootstrap mode (availability routing)
+agent.observationCount ≥ policy.minimumObservations  →  threshold mode (trust routing)
+```
+
+`RoutingPolicy.isBootstrap(int agentObservations)` makes this determination explicit in the API:
+
+```java
+public record RoutingPolicy(...) {
+    public boolean isBootstrap(int agentObservations) {
+        return minimumObservations.isPresent()
+            && agentObservations < minimumObservations.getAsInt();
+    }
+
+    public boolean isBorderline(double trustScore) {
+        return borderlineMargin.isPresent() && threshold.isPresent()
+            && trustScore >= threshold.getAsDouble()
+            && trustScore < threshold.getAsDouble() + borderlineMargin.getAsDouble();
+    }
+}
+```
+
+### The degradation guarantee
+
+**The system never fails or blocks because of missing trust data.** When an agent is in bootstrap for a capability, they are treated as eligible (availability routing). When no agent meets threshold and `fallbackType` is set, the policy defines the fallback. The fallback is never "do nothing."
+
+This guarantee means devtown on day-1 of a fresh installation behaves identically to Gastown — any available agent gets the work. As attestations accumulate, routing quality improves automatically. No deployment ceremony. No manual trust seeding.
+
+### What this means for `DevtownCapabilityRegistry`
+
+The default `minimumObservations` values reflect the stakes of each capability:
+
+| Capability | `minimumObservations` | Reasoning |
+|-----------|----------------------|-----------|
+| `security-review` | 10 | High stakes — need credible history before threshold applies |
+| `merge-executor` | 15 | Irreversible — highest observation requirement |
+| `architecture-review` | 8 | Significant stakes |
+| `style-review` | 5 | Low stakes — faster trust path |
+
+Capabilities with no threshold (`code-analysis`, `ci-runner`, etc.) have no `minimumObservations` — they use availability routing permanently.
+
+### Platform pattern
+
+The maturity model is not devtown-specific. Any CaseHub application that uses trust-based routing faces the same cold-start problem. The pattern — bootstrap → emerging → active → adaptive, governed by `minimumObservations` and `borderlineMargin` in the routing policy — is a reusable methodology. Tracked for PLATFORM.md: casehubio/parent#14.
+
+---
+
+## File Layout
+
+```
+devtown-domain/src/main/java/io/casehub/devtown/
+  domain/
+    ReviewDomain.java
+    AgentQualification.java
+    HumanDecision.java
+    HumanOversight.java
+    DevtownTrustDimension.java
+    RoutingPolicy.java
+    DevtownCapabilityRegistry.java
+  domain/spi/
+    CapabilityRegistry.java
+
+devtown-domain/src/test/java/io/casehub/devtown/domain/
+  ReviewDomainTest.java
+  AgentQualificationTest.java
+  HumanDecisionTest.java
+  HumanOversightTest.java
+  DevtownTrustDimensionTest.java
+  RoutingPolicyTest.java
+  DevtownCapabilityRegistryTest.java
+
+devtown-app/src/main/java/io/casehub/devtown/app/
+  CapabilityRegistryBean.java     @ApplicationScoped, extends DevtownCapabilityRegistry
+
+devtown-app/src/test/java/io/casehub/devtown/app/
+  DevtownBootTest.java            extended: verify CapabilityRegistry CDI discovery
+```
+
+---
+
+## Testing Strategy
+
+### Constants (correctness)
+
+| Test class | What | Type |
+|-----------|------|------|
+| `ReviewDomainTest` | All 6 constants non-null, non-blank, unique, no duplicates across other types | Correctness |
+| `AgentQualificationTest` | Both constants non-null, non-blank, unique, no overlap with ReviewDomain | Correctness |
+| `HumanDecisionTest` | Constant non-null, non-blank, prefixed `human-decision:` | Correctness |
+| `HumanOversightTest` | Constant non-null, non-blank, prefixed `human-oversight:` | Correctness |
+| `DevtownTrustDimensionTest` | All 3 constants non-null, non-blank, unique | Correctness |
+
+### `RoutingPolicy` (correctness + robustness + maturity phases)
+
+| Test | Type |
+|------|------|
+| `isBorderline()` returns true when score is within threshold + margin | Correctness |
+| `isBorderline()` returns false when score is below threshold | Robustness |
+| `isBorderline()` returns false when margin is empty | Robustness |
+| `isBorderline()` returns false when score is above threshold + margin | Correctness |
+| `isBootstrap(4)` returns true when `minimumObservations = 10` | Correctness |
+| `isBootstrap(10)` returns false when `minimumObservations = 10` | Correctness |
+| `isBootstrap(0)` returns false when `minimumObservations` is empty (no gate) | Robustness |
+| `isBootstrap()` and `isBorderline()` are mutually exclusive for valid inputs | Correctness |
+| Record equality — two policies with same fields are equal | Correctness |
+
+### `DevtownCapabilityRegistry` (happy path + robustness)
+
+| Test | Type |
+|------|------|
+| `capabilities()` contains all 10 capability strings | Correctness |
+| `capabilities()` returns immutable set | Robustness |
+| `policy("security-review")` threshold = 0.70 | Correctness |
+| `policy("security-review")` minimumObservations = 10 | Correctness |
+| `policy("security-review")` borderlineMargin = 0.05 | Correctness |
+| `policy("architecture-review")` threshold = 0.65 | Correctness |
+| `policy("merge-executor")` threshold = 0.80, minimumObservations = 15 | Correctness |
+| `policy("code-analysis")` returns `Optional.empty()` | Correctness |
+| `policy("ci-runner")` returns `Optional.empty()` | Correctness |
+| All threshold values in `[0.0, 1.0]` | Correctness |
+| `isKnown("security-review")` returns true | Happy path |
+| `isKnown("unknown")` returns false | Robustness |
+| `policy(null)` throws `NullPointerException` | Robustness |
+| `isKnown(null)` throws `NullPointerException` | Robustness |
+| `isBorderline()` on security-review policy with borderline score | Happy path |
+
+### Integration
+
+| Test | Type |
+|------|------|
+| `CapabilityRegistryBean` injectable as `CapabilityRegistry` in Quarkus CDI context | Integration |
+| `CapabilityRegistryBean.capabilities()` returns full set in live context | Integration |
+
+---
+
+## Null Policy
+
+`policy(null)` and `isKnown(null)` throw `NullPointerException("capability must not be null")`. Callers that reach routing with a null capability tag have a bug — fail fast.
+
+---
+
+## Ledger Dependency Note
+
+Per-capability quality dimensions (e.g., security-review thoroughness specifically, not global thoroughness) require `ScoreType.CAPABILITY_DIMENSION` in the ledger (ledger#76, devtown#19). `DevtownCapabilityRegistry` and `RoutingPolicy` are designed to accommodate this when it ships — `policy()` can be extended to include per-capability dimension floors without changing the SPI contract.
+
+---
+
+## Out of Scope
+
+- No Quarkus CDI annotations in `devtown-domain`
+- No persistence, Flyway, or datasource configuration
+- No capability metadata beyond tag string and routing policy (input/output schemas belong in Epic 3 CasePlanModel YAML)
+- No trust dimension scoring logic — dimension *names* only; scoring is in `casehub-ledger`
+- `BATCH_BISECT`, `COORDINATED_MERGE`, `COORDINATED_ROLLBACK` deferred to Epics 4/5 with naming review (devtown#20)
+- `NOTIFY` removed — `casehub-connectors` handles notification delivery directly

--- a/docs/specs/2026-05-13-contributor-trust-open-source.md
+++ b/docs/specs/2026-05-13-contributor-trust-open-source.md
@@ -1,0 +1,190 @@
+# Contributor Trust: Filtering AI PR Slop Without Breaking Good Contributors
+
+**Date:** 2026-05-13  
+**Status:** Proposal — stakeholder buy-in  
+**Audience:** Engineers familiar with open source workflows; no prior knowledge of CaseHub required
+
+---
+
+## The problem
+
+Open source maintainers are overwhelmed. GitHub makes submission free, and AI coding assistants have made it trivial to generate plausible-looking but low-quality PRs at scale. Projects like Quarkus are seeing a flood of submissions that require more reviewer time to reject than the code took to generate.
+
+The standard fixes don't hold up:
+
+- **Rate limiting** — punishes prolific genuine contributors
+- **Minimum account age** — gamed in a day
+- **AI detection** — an arms race with no sustainable winning side
+- **Stricter guidelines** — read by humans, ignored by slop generators
+
+The underlying problem isn't that we can't identify AI slop. It's that a first-time human contributor and a fresh slop account look identical — no history.
+
+---
+
+## The proposal
+
+Route PRs based on accumulated contributor reputation. Not blocking who submits, but controlling what gets reviewed first.
+
+A contributor starts with no score. Outcomes build it:
+- PR merges cleanly on first submission → score rises
+- PR returned for rework → score drops
+- PR rejected outright → score drops faster
+
+High-reputation contributors get fast-tracked. New or low-reputation contributors land in a triage queue. Nothing is blocked — the queue just has a different priority.
+
+The key property: **slop generators can't game this**. A new GitHub account means zero score, which means triage. To build reputation, PRs have to actually get merged. The score is the barrier.
+
+---
+
+## How the score works: the Bayesian Beta model
+
+A naive approach counts merged PRs divided by submitted PRs. The problem: 2 merged from 2 submitted gives the same percentage as 200 merged from 200 — but these are not equivalent. One might be luck.
+
+The platform uses a **Bayesian Beta model** — the same probabilistic framework used in medical trial analysis and A/B testing — which tracks two things simultaneously: the *estimated* success rate and the *confidence* in that estimate. With 2 data points, the confidence is low. With 200, the estimate is reliable. The model knows the difference.
+
+Before seeing any evidence, every contributor starts with a prior assumption — roughly "unknown." Each PR outcome updates that assumption. A merge shifts the distribution toward "reliable"; a rejection shifts it toward "unreliable." A small number of outcomes produces a wide, uncertain distribution. The model won't act confidently on thin evidence.
+
+The practical consequence: an account with 1 merged PR does not jump the queue. The platform requires a minimum number of observations before the score carries weight — configurable per project. A small library might set this at 5; a large security-critical project at 20.
+
+This is also why the score doesn't just track acceptance rate — it tracks *confidence in that acceptance rate*. A contributor at 80% from 5 PRs gets treated more cautiously than one at 75% from 50. The raw percentage would rank them incorrectly. The Bayesian model ranks them correctly.
+
+---
+
+## Bootstrapping from history
+
+Most open source projects don't need to wait months for the system to accumulate evidence. The evidence already exists.
+
+GitHub's API exposes the full PR history for any public repository. Before deploying, you mine that history: for every contributor account, count submissions, merges, rejections, and return-for-rework cycles going back years. Feed those outcomes into the Bayesian model. On day one, established contributors arrive with scores that reflect their actual track record — not a blank slate.
+
+A project like Quarkus with ten years of PR history can immediately differentiate between a contributor with 47 merged PRs over three years and an account created last week. New accounts start at zero, which is exactly right.
+
+The history mining can go further: which PRs touched which file paths? A contributor with 30 merged PRs all touching documentation scores differently for a security-module change than one with 30 PRs spanning authentication, crypto, and networking. The platform can segment trust by domain if the project chooses.
+
+---
+
+## What the platform provides
+
+**Bayesian Beta scoring** — already implemented in the foundation for scoring AI agent reliability. The model, the update logic, the confidence tracking, and the configurable minimum-observations threshold are all in place. Bayesian Beta is well-established across decades of clinical trial design, A/B testing, and recommender systems. We're applying proven mathematics through new infrastructure, pointed at a new problem.
+
+**EigenTrust propagation** — published at WWW 2003 and widely used in peer-to-peer reputation systems, this is the same family of ideas as Google's PageRank. When a maintainer with 8 years of commits vouches for a newcomer, that vouch carries more weight than one from someone who joined three months ago. Trust propagates through the vouching graph, attenuated at each step. Circular inflation rings — A vouches for B, B vouches for A — collapse automatically under the mathematics. Also already implemented in the platform.
+
+**Work queues and priority views** — the trust score becomes a practical workflow tool through the platform's work queue layer. Each queue is a labelled, filtered, prioritised view of incoming PRs:
+
+- **Fast-track queue** — high-trust contributors, sorted by submission time
+- **Triage queue** — zero or low-trust contributors; AI slop and genuine newcomers alike, ordered by file-path risk
+- **Security queue** — any PR touching security-sensitive paths, regardless of contributor trust
+- **Borderline queue** — contributors within the confidence margin; lighter-weight review before promotion
+
+Labels can combine trust signals with static analysis. A zero-trust PR touching only documentation is lower risk than a zero-trust PR touching authentication. Both land in triage, but the ordering reflects the difference. The queues also support **SLA tracking** — a PR sitting in triage for 7 days without action gets surfaced automatically — and **reviewer load balancing**, distributing assignments across available reviewers based on capacity.
+
+**Cryptographic audit trail** — every score update is recorded in a tamper-evident ledger. The records are cryptographically chained: you can't retroactively alter a score history without breaking the chain. Contributors can inspect exactly which events drove their score. Maintainers can verify the system is making decisions honestly. The EU AI Act's Art. 12 requires traceability for automated decisions affecting human participants — a system routing contributors algorithmically without an auditable record has a compliance problem from the start. The platform has this built in.
+
+---
+
+## Vouching: the bootstrapping problem
+
+The scoring system handles established contributors and clear bad actors well. The gap is genuine newcomers — good contributors with no history.
+
+Vouching solves this. A high-reputation contributor vouches for a newcomer, temporarily elevating their score. The voucher's own score is at risk: if the vouchee's PRs get returned, the voucher loses points too.
+
+EigenTrust governs the weight of each vouch. A vouch from a 10-year core committer carries more than one from a contributor who merged their first PR last month. Constraints enforced by the system:
+
+- You can only vouch for contributors with *lower* reputation than you — no mutual inflation
+- Vouching capacity is limited — you can't sponsor hundreds of people simultaneously
+- The trust graph is visible — the chain of vouches is inspectable
+
+This is how professional references work, except the cost is automatic and quantified. A senior maintainer can get a trusted colleague into the fast lane immediately. That colleague now has skin in the game.
+
+---
+
+## A day in the life
+
+Maria is a Quarkus core maintainer. Monday morning, she opens her review dashboard.
+
+**Fast-track queue: 4 PRs.** Contributors the system is confident in — combined, they have 300+ merged PRs and clean track records. She skims them efficiently. Three merge same-day. One needs a small change; she leaves a comment and it's back within the hour.
+
+**Borderline queue: 2 PRs.** Contributors with enough history to be promising but not enough to be certain. She gives these a proper read. One is solid — she approves it and the contributor's score climbs. The other has an issue she flags; the contributor fixes it.
+
+**Triage queue: 31 PRs.** The flood. But already ordered: PRs touching documentation at the top, PRs touching security or networking at the bottom. She works through the top 10, rejects 8 as slop, approves 2 from what look like genuine first-timers.
+
+One of those first-timers messages her — they've been trying to contribute for weeks and don't understand the delay. She looks at their history: 3 merged PRs, clean, but the minimum observations threshold is 5. She vouches for them. They move to the borderline queue immediately.
+
+By noon, Maria has processed 40 PRs without touching the bottom half of triage, where the worst slop sits. Before this system, she'd have spent the morning deciding which pile to ignore.
+
+---
+
+## How this fits into DevTown: one pipeline, two trust dimensions
+
+DevTown already manages PR review as a case with goals — `pr-approved`, `security-verified`, `ci-passing` — coordinating AI agents and human reviewers through trust-weighted routing. Contributor trust doesn't add a second system alongside this. It extends the same case model upstream, to the moment the PR arrives.
+
+Every PR is a case with two actor dimensions:
+
+1. **The submitter** — who opened this PR? What is their track record?
+2. **The reviewers** — who should evaluate it? Are they qualified for this kind of work?
+
+Both dimensions live in the same trust ledger. The pipeline is continuous:
+
+```
+PR submitted
+  → contributor trust checked → intake queue assigned
+  → reviewer assigned by trust-weighted routing
+  → review outcome recorded
+  → contributor score updated
+  → reviewer score updated
+  → both scores inform the next PR
+```
+
+Two self-improving feedback loops run in parallel. A contributor whose PRs consistently merge cleanly builds a score that earns faster review. A reviewer who accurately catches issues gets routed to more complex work. Neither loop requires manual curation — outcomes drive both.
+
+**Three views, one system**
+
+- **Intake dashboard** — for maintainers. Prioritised queues, contributor scores, vouching controls, SLA alerts.
+- **Review dashboard** — for reviewers. Assigned cases ordered by urgency, complexity, and capability match.
+- **Contributor view** — for PR authors. Their own score, which events drove it, active vouches, queue position.
+
+Three audiences, one data model.
+
+**Open source vs internal team: graceful degradation**
+
+For an internal team where everyone is trusted, contributor trust is effectively inactive — the minimum observations threshold is set to zero, or all team members are pre-vouched. The system operates as pure reviewer routing with no intake friction.
+
+For an open source project, both dimensions are live. The intake queue is the new high-value capability; the reviewer routing is the foundation it sits on.
+
+The open source use case is also the *more complete* demonstration of DevTown. Internal teams only see reviewer routing. Open source maintainers see the full pipeline — intake prioritisation, reviewer routing, trust accumulation on both sides, vouching, audit trail, SLA management — in a single coherent workflow.
+
+---
+
+## Identity
+
+The weak point: reputation lives on GitHub account identity. A determined adversary creates new accounts.
+
+But new accounts always start in triage. Building reputation requires PRs that actually get merged — real effort, even for adversaries. Vouching provides a social escape valve for genuine newcomers. The adversary who games this has to put in the work of a genuine contributor, at which point the incentive disappears.
+
+---
+
+## What we'd still need to build
+
+The scoring model, trust propagation, audit ledger, and work queue infrastructure are already in the platform. What's new:
+
+1. **GitHub event integration** — webhooks for PR lifecycle events feeding into contributor score updates
+2. **History mining** — a one-time import of existing PR history to bootstrap scores at deployment
+3. **Routing logic** — queue assignment at PR submission, driven by score and confidence threshold
+4. **Vouching interface** — a maintainer-facing tool for issuing vouches
+5. **Contributor score visibility** — so contributors understand their standing and can raise disputes
+
+---
+
+## What this isn't
+
+- **Not AI detection.** We track outcomes, not code content.
+- **Not gatekeeping.** Every PR enters the queue. Reputation controls priority.
+- **Not a new trust model.** Bayesian Beta and EigenTrust are established mathematics. The infrastructure is new; the models are not.
+
+---
+
+## Open questions
+
+1. **Score scope** — per-project, per-organisation, or portable across open source?
+2. **Vouching governance** — maintainers only, or any sufficiently trusted contributor?
+3. **Score decay** — should a dormant account retain its score indefinitely, or decay without recent activity?
+4. **Contributor visibility** — can contributors see their own score? Can they dispute individual events?

--- a/docs/specs/2026-05-15-layer1-partb-naive-service-design.md
+++ b/docs/specs/2026-05-15-layer1-partb-naive-service-design.md
@@ -88,4 +88,4 @@ The naive service carries `@DefaultBean`. Any `@ApplicationScoped` implementatio
 - No real specialist service calls (stubs only)
 - No CDI-injected collaborators in the naive impl
 - No Jackson/JSON configuration (Quarkus REST handles serialisation)
-- No additional Quarkus extensions
+- No additional Quarkus exten

--- a/docs/specs/2026-05-15-layer1-partb-naive-service-design.md
+++ b/docs/specs/2026-05-15-layer1-partb-naive-service-design.md
@@ -1,0 +1,91 @@
+# Layer 1 Part B — Naive PR Review Service
+
+**Issue:** devtown#27  
+**Epic:** epic-pr-review-case (prerequisite step)  
+**Date:** 2026-05-15
+
+---
+
+## What This Is
+
+The second part of Layer 1 in the devtown tutorial. Part A (Epics 1–2) established the domain vocabulary and scaffold. Part B establishes the teaching baseline: the code a team would write without CaseHub. Every subsequent layer displaces it at the CDI level via `@DefaultBean`.
+
+---
+
+## Components
+
+### `PrReviewApplicationService` (port interface)
+
+Location: `app/src/main/java/io/casehub/devtown/app/PrReviewApplicationService.java`
+
+```java
+public interface PrReviewApplicationService {
+    PrReviewOutcome review(PrPayload pr);
+}
+```
+
+The CDI displacement boundary. Each subsequent layer provides a non-`@DefaultBean @ApplicationScoped` implementation that displaces the naive one. Both DTOs are plain records — no CaseHub types.
+
+### `PrPayload` (input record)
+
+Location: `app/src/main/java/io/casehub/devtown/app/PrPayload.java`
+
+Fields: `repo` (String), `prNumber` (int), `headSha` (String), `linesChanged` (int).
+
+### `PrReviewOutcome` (output record)
+
+Location: `app/src/main/java/io/casehub/devtown/app/PrReviewOutcome.java`
+
+Fields: `verdict` (String), `findings` (List<String>).
+
+### `NaivePrReviewService` (the anti-pattern)
+
+Location: `app/src/main/java/io/casehub/devtown/app/NaivePrReviewService.java`
+
+`@ApplicationScoped @DefaultBean`. Implements `PrReviewApplicationService`. Makes direct calls via private methods returning stub results. No CDI collaborators — the stubs are intentionally hollow. The gap comments are the pedagogical artifact.
+
+Required gap comments (one per structural gap):
+- No attribution — which agent ran this? No record.
+- No response SLA — analysis can stall indefinitely.
+- No formal DECLINE — if a specialist can't review, it silently fails.
+- No tamper-evident audit trail — cannot trace a production incident to this review.
+- No trust weighting — novice and expert treated identically.
+
+### `PrReviewResource` (REST dispatcher)
+
+Location: `app/src/main/java/io/casehub/devtown/app/PrReviewResource.java`
+
+`POST /api/reviews`. Injects `PrReviewApplicationService`. No business logic. No auth (auth-retrofit ready: resource method is trivially annotatable with `@RolesAllowed`).
+
+---
+
+## Testing
+
+**Unit test** (`NaivePrReviewServiceTest`): plain `new NaivePrReviewService()`, no Quarkus. Calls `review()` with a stub `PrPayload`. Verifies:
+- Returns a non-null `PrReviewOutcome`
+- `verdict` is a non-null, non-blank String
+- `findings` is a non-null List
+- Service is instantiable without a container
+
+**Boot test** (`DevtownBootTest`, already exists): already verifies `@QuarkusTest` starts and CDI wiring is live. No new boot test needed — the existing test covers CDI discovery of `PrReviewApplicationService` once the bean is on the classpath.
+
+---
+
+## Module
+
+All new files go in `app/`. The `domain/` module stays unchanged — no domain types are added for this layer. The interface, DTOs, naive impl, and REST resource are all application-layer concerns.
+
+---
+
+## Displacement Contract
+
+The naive service carries `@DefaultBean`. Any `@ApplicationScoped` implementation of `PrReviewApplicationService` without `@DefaultBean` displaces it at CDI resolution time. The naive class stays in the build across all layers — it is never deleted.
+
+---
+
+## Non-goals
+
+- No real specialist service calls (stubs only)
+- No CDI-injected collaborators in the naive impl
+- No Jackson/JSON configuration (Quarkus REST handles serialisation)
+- No additional Quarkus extensions

--- a/docs/specs/2026-05-19-epic3-pr-review-caseplanmodel-design.md
+++ b/docs/specs/2026-05-19-epic3-pr-review-caseplanmodel-design.md
@@ -1,0 +1,291 @@
+# Epic 3: PR Review CasePlanModel Design
+
+**Issue:** devtown#10
+**Date:** 2026-05-19
+**Layer:** 5 — casehub-engine (adaptive routing on code content)
+
+---
+
+## Architecture
+
+The PR review case definition follows the three-layer architecture prescribed by
+`casehub-parent/docs/protocols/casehub/case-definition-layers.md`:
+
+- **YAML** (`review/src/main/resources/devtown/pr-review.yaml`) — runtime artifact,
+  configurable per-repo without redeployment
+- **`CaseDefinitionYamlMapper`** — converts YAML to canonical `CaseDefinition`
+- **Canonical model** (`io.casehub.api.model.CaseDefinition`) — what the engine operates on
+- **Fluent DSL** — used in tests only; supports `LambdaExpressionEvaluator` which YAML cannot express
+
+`PrReviewCaseService` (`@ApplicationScoped`, no `@DefaultBean`) displaces
+`NaivePrReviewService` (`@DefaultBean`) at CDI resolution time — the Layer 1 teaching
+baseline is never deleted, just made inactive.
+
+### Module placement
+
+```
+review/src/main/resources/devtown/pr-review.yaml
+review/src/main/java/.../review/PrReviewCaseHub.java         extends YamlCaseHub
+review/src/main/java/.../review/PrReviewCaseService.java     @ApplicationScoped, no @DefaultBean
+review/src/test/java/.../review/PrReviewCaseDefinition.java  fluent DSL factory, test-only
+review/src/test/java/.../review/PrReviewBindingConditionTest.java
+review/src/test/java/.../review/PrReviewCaseHubTest.java     @QuarkusTest
+```
+
+---
+
+## CaseContext Schema
+
+Built by `PrReviewCaseService` at case-open time. Two top-level objects injected
+into the initial context:
+
+```json
+{
+  "pr": {
+    "id": "456",
+    "repo": "casehubio/devtown",
+    "linesChanged": 342,
+    "baseRef": "main",
+    "headSha": "abc123"
+  },
+  "policy": {
+    "humanApprovalThreshold": 500,
+    "securityReviewRequired": true,
+    "requireSeniorApproval": false
+  }
+}
+```
+
+Workers write results back to the context. Full schema after a complete run:
+
+```json
+{
+  "pr": { ... },
+  "policy": { ... },
+  "codeAnalysis": {
+    "complete": true,
+    "securitySensitive": true,
+    "architectureCrossing": false,
+    "findings": {}
+  },
+  "securityReview":      { "outcome": "APPROVED | DECLINED | FAILED" },
+  "architectureReview":  { "outcome": "APPROVED | DECLINED | FAILED" },
+  "styleCheck":          { "outcome": "APPROVED | DECLINED | FAILED" },
+  "testCoverage":        { "outcome": "APPROVED | DECLINED | FAILED" },
+  "performanceAnalysis": { "outcome": "APPROVED | DECLINED | FAILED" },
+  "ci":                  { "status": "passing | failing | pending" },
+  "humanApproval":       { "status": "approved | rejected" }
+}
+```
+
+All agent-performed checks use `outcome` (three-value enum). This is intentional:
+a style linter that doesn't support the PR's language DECLINES rather than failing.
+Epic 7 (devtown#14) routes differently on DECLINED vs FAILED — the schema supports
+this from day one. `ci` uses `status` (external system, not a capability agent).
+`humanApproval` uses `status` (WorkItem resolution semantics).
+
+---
+
+## Goals and Completion
+
+```yaml
+goals:
+  - name: pr-approved
+    kind: success
+    condition: >
+      .securityReview.outcome == "APPROVED" and
+      (.codeAnalysis.architectureCrossing == false or .architectureReview.outcome == "APPROVED") and
+      .styleCheck.outcome == "APPROVED" and
+      .testCoverage.outcome == "APPROVED" and
+      .performanceAnalysis.outcome == "APPROVED"
+
+  - name: security-verified
+    kind: success
+    condition: >
+      .codeAnalysis.securitySensitive == false or
+      .securityReview.outcome == "APPROVED"
+
+  - name: ci-passing
+    kind: success
+    condition: ".ci.status == \"passing\""
+
+completion:
+  success:
+    allOf:
+      - pr-approved
+      - security-verified
+      - ci-passing
+```
+
+Architecture review is folded into `pr-approved` with a conditional expression
+(`.codeAnalysis.architectureCrossing == false or ...`) because the binding only fires
+when analysis finds a cross-API change. Making it a standalone goal would leave it
+permanently unsatisfied on PRs where it never fires.
+
+---
+
+## Bindings
+
+Nine bindings in four groups. All trigger on `contextChange` — automatic parallelism
+means all satisfied bindings fire simultaneously on every context update.
+
+### Group 1 — Entry (fire immediately on PR arrival, in parallel)
+
+```yaml
+- name: initial-analysis
+  on: { contextChange: {} }
+  when: ".pr != null and .codeAnalysis == null"
+  capability: code-analysis
+
+- name: run-ci
+  on: { contextChange: {} }
+  when: ".pr != null and .ci == null"
+  capability: ci-runner
+```
+
+### Group 2 — Content-driven (fire after analysis completes, all in parallel)
+
+```yaml
+- name: security-review
+  on: { contextChange: {} }
+  when: ".codeAnalysis.complete == true and .codeAnalysis.securitySensitive == true and .securityReview == null"
+  capability: security-review
+
+- name: architecture-review
+  on: { contextChange: {} }
+  when: ".codeAnalysis.complete == true and .codeAnalysis.architectureCrossing == true and .architectureReview == null"
+  capability: architecture-review
+
+- name: style-check
+  on: { contextChange: {} }
+  when: ".codeAnalysis.complete == true and .styleCheck == null"
+  capability: style-review
+
+- name: test-coverage
+  on: { contextChange: {} }
+  when: ".codeAnalysis.complete == true and .testCoverage == null"
+  capability: test-coverage
+
+- name: performance-analysis
+  on: { contextChange: {} }
+  when: ".codeAnalysis.complete == true and .performanceAnalysis == null"
+  capability: performance-analysis
+```
+
+Style, test-coverage, and performance-analysis fire simultaneously — automatic
+parallelism from the binding system. No explicit parallel declaration needed.
+
+### Group 3 — Human gate (fires alongside CI when PR exceeds threshold)
+
+```yaml
+- name: human-approval
+  on: { contextChange: {} }
+  when: ".pr.linesChanged > .policy.humanApprovalThreshold and .humanApproval == null"
+  humanTask:
+    title: "PR #{{ .pr.id }} requires senior approval"
+    candidateGroups: [ "senior-architects" ]
+    expiresIn: PT48H
+```
+
+Fires immediately if the PR exceeds the threshold — in parallel with CI, not after it.
+Total time = max(human review, CI), not sum. The threshold is configurable via
+`devtown.policy.human-approval-threshold` (default 500 lines).
+
+HITL wiring gap: `casehub-work-adapter` is not yet configured for devtown — the
+WorkItem is created but the case does not resume automatically on human completion.
+See devtown#30 for the follow-up integration test once wiring lands.
+
+### Group 4 — Merge (fires when all conditions are satisfied)
+
+```yaml
+- name: merge
+  on: { contextChange: {} }
+  when: >
+    .securityReview.outcome == "APPROVED" and
+    (.codeAnalysis.architectureCrossing == false or .architectureReview.outcome == "APPROVED") and
+    .styleCheck.outcome == "APPROVED" and
+    .testCoverage.outcome == "APPROVED" and
+    .performanceAnalysis.outcome == "APPROVED" and
+    (.pr.linesChanged <= .policy.humanApprovalThreshold or .humanApproval.status == "approved") and
+    .ci.status == "passing"
+  capability: merge-executor
+```
+
+---
+
+## Scoped Settings Stub
+
+Policy values come from `@ConfigProperty` until `casehub-platform-api` (parent#26)
+delivers `PreferenceProvider`. The CaseContext shape does not change when the SPI
+arrives — only the injection point in `PrReviewCaseService` changes.
+
+```java
+@ConfigProperty(name = "devtown.policy.human-approval-threshold", defaultValue = "500")
+int humanApprovalThreshold;
+
+@ConfigProperty(name = "devtown.policy.security-review-required", defaultValue = "true")
+boolean securityReviewRequired;
+
+@ConfigProperty(name = "devtown.policy.require-senior-approval", defaultValue = "false")
+boolean requireSeniorApproval;
+// TODO(parent#26): replace with PreferenceProvider.resolve(scope).asMap()
+```
+
+---
+
+## Testing Strategy
+
+### Tier 1 — Binding condition unit tests (`PrReviewBindingConditionTest`)
+
+Pure Java, no Quarkus, no YAML parsing. Uses `PrReviewCaseDefinition` fluent DSL
+factory with `LambdaExpressionEvaluator`. Tests that each binding fires at exactly
+the right moment.
+
+Required cases:
+- `initialAnalysis` fires when PR arrives and no analysis yet
+- `initialAnalysis` does not fire again when analysis already present
+- `securityReview` fires only when `securitySensitive == true`
+- `securityReview` does not fire when `securitySensitive == false`
+- `architectureReview` fires only when `architectureCrossing == true`
+- `styleCheck`, `testCoverage`, `performanceAnalysis` all fire when analysis complete
+- `humanApproval` fires only when `linesChanged > threshold`
+- `humanApproval` does not fire when `linesChanged <= threshold`
+- `merge` does not fire until all checks approved and CI passing
+- `merge` fires when all conditions simultaneously satisfied
+- `merge` does not fire when `architectureCrossing == true` but `architectureReview` absent
+
+### Tier 2 — YAML round-trip (`PrReviewCaseHubTest`)
+
+Single `@QuarkusTest`. Verifies the YAML parses cleanly and the definition has the
+expected structure.
+
+```java
+assertThat(def.getBindings()).hasSize(9);
+assertThat(def.getGoals()).hasSize(3);
+assertThat(def.getCapabilities()).hasSize(8);  // code-analysis, security-review,
+                                                // architecture-review, style-review,
+                                                // test-coverage, performance-analysis,
+                                                // ci-runner, merge-executor
+```
+
+---
+
+## Foundation Gates and Deferred Concerns
+
+| Concern | Status | Tracked |
+|---------|--------|---------|
+| casehub-engine P0 (engine#186) | ✅ Done | — |
+| HITL wiring (`casehub-work-adapter`) | ⚠️ Gap — bindings defined, integration test deferred | devtown#30 |
+| Scoped preferences SPI | ⚠️ `@ConfigProperty` stub — replace when parent#26 lands | parent#26 |
+| Pluggable expression evaluator factory | ⚠️ Engine gap — mapper hardcodes JQ | engine#289 |
+| Trust-weighted worker selection | 🔲 Epic 6 | devtown#13 |
+| DECLINED/FAILED routing | 🔲 Epic 7 | devtown#14 |
+
+---
+
+## Out of Scope
+
+- Failure bindings (DECLINED/FAILED routing and backup agent cascading) — Epic 7
+- Trust-weighted reviewer routing — Epic 6
+- GitHub webhook integration (PR arrival trigger) — Epic 8
+- Merge queue (casehub-refinery) — Epic 4

--- a/docs/specs/2026-05-21-hitl-human-approval-lifecycle-design.md
+++ b/docs/specs/2026-05-21-hitl-human-approval-lifecycle-design.md
@@ -1,0 +1,136 @@
+# Design: HITL Human Approval Lifecycle Test
+
+**Issue:** devtown#30  
+**Branch:** issue-30-hitl-human-approval-test  
+**Date:** 2026-05-21
+
+## Problem
+
+The `human-approval` binding in `pr-review.yaml` uses `humanTask:` to create a
+casehub-work WorkItem. `casehub-engine-work-adapter` (wired in devtown#33) bridges
+WorkItem lifecycle events back to the engine, resuming the case from WAITING state
+when a human completes the WorkItem. This round-trip has no end-to-end integration
+test. Until one exists, the wiring is unverified below unit level.
+
+## What the test covers
+
+1. A PR review case with `linesChanged > humanApprovalThreshold` causes the
+   `human-approval` binding to fire and create a `WorkItem`.
+2. The WorkItem carries the correct `callerRef` (`case:{id}/pi:{planItemId}`) and
+   title (`PR approval required`).
+3. Completing the WorkItem via `WorkItemService.completeFromSystem()` with resolution
+   `{"decision": "approved"}` triggers `WorkItemLifecycleAdapter`, which applies the
+   `outputMapping` `{ humanApproval: { status: .decision } }` and fires `CONTEXT_CHANGED`.
+4. The case context is updated: `humanApproval.status == "approved"`.
+5. With all other conditions already satisfied, the `merge` binding fires (its PlanItem
+   transitions to `RUNNING`).
+
+## Test class
+
+**`HumanApprovalLifecycleTest`** — `app/src/test/java/io/casehub/devtown/app/`
+
+`@QuarkusTest`. No `@TestHTTPEndpoint` — exercises the internal service and engine
+boundary directly, not the REST layer.
+
+### Injections
+
+```java
+@Inject PrReviewCaseHub    caseHub;
+@Inject WorkItemStore      workItemStore;
+@Inject WorkItemService    workItemService;
+@Inject BlackboardRegistry blackboardRegistry;
+```
+
+### Initial context strategy
+
+All parallel checks are pre-seeded in the initial context so only `human-approval`
+fires on the first engine evaluation. This avoids needing capability workers registered
+in the test runtime:
+
+| Key                | Value                                                          | Effect                             |
+|--------------------|----------------------------------------------------------------|------------------------------------|
+| `pr.linesChanged`  | 600                                                            | Exceeds threshold of 500           |
+| `policy.humanApprovalThreshold` | 500                                           | Sets the threshold                 |
+| `codeAnalysis`     | `{complete: true, securitySensitive: false, architectureCrossing: false}` | Suppresses initial-analysis, security-review, architecture-review |
+| `styleCheck`       | `{outcome: "APPROVED"}`                                        | Suppresses style-check binding     |
+| `testCoverage`     | `{outcome: "APPROVED"}`                                        | Suppresses test-coverage binding   |
+| `performanceAnalysis` | `{outcome: "APPROVED"}`                                     | Suppresses performance-analysis binding |
+| `ci`               | `{status: "passing"}`                                          | Suppresses run-ci binding          |
+
+With this context, only `human-approval` evaluates true. `merge` evaluates false
+(no `humanApproval` yet).
+
+### Single test method: `humanApproval_fullLifecycle`
+
+Five sequential async checkpoints via Awaitility `untilAsserted`:
+
+**Checkpoint 1 — start case**
+```
+UUID caseId = caseHub.startCase(initialContext).toCompletableFuture().get(5, SECONDS);
+```
+`startCase()` resolves after the case is persisted. Event bus delivery (binding
+evaluation, WorkItem creation) is async — hence the subsequent polls.
+
+**Checkpoint 2 — WorkItem created**
+```
+await(5s).untilAsserted:
+  workItemStore.scanAll() has an item whose callerRef contains caseId.toString()
+  wi.title == "PR approval required"
+```
+`HumanTaskScheduleHandler` (blocking = true ✅) creates the WorkItem on the event
+bus worker thread. The `callerRef` format is `case:{caseId}/pi:{planItemId}`.
+
+**Checkpoint 3 — complete the WorkItem**
+```
+workItemService.completeFromSystem(wi.id, "system", "{\"decision\": \"approved\"}")
+```
+Fires `WorkItemLifecycleEvent` synchronously and asynchronously. The async observer
+(`WorkItemLifecycleAdapter`) applies the `outputMapping` and fires `CONTEXT_CHANGED`.
+
+**Checkpoint 4 — context updated**
+```
+await(5s).untilAsserted:
+  caseHub.query(caseId, "humanApproval.status").toCompletableFuture().get(1s) == "approved"
+```
+`WorkItemLifecycleAdapter.applyOutputMapping()` applies JQ `{ humanApproval: { status: .decision } }`
+to the resolution JSON. Two async hops from completion to context update (lifecycle
+observer → CONTEXT_CHANGED → binding re-evaluation).
+
+**Checkpoint 5 — merge binding fires**
+```
+await(5s).untilAsserted:
+  blackboardRegistry.get(caseId)
+    .flatMap(plan -> plan.getPlanItemByBindingName("merge"))
+    .map(PlanItem::getStatus)
+    .orElseThrow() == PlanItemStatus.RUNNING
+```
+With `humanApproval.status == "approved"` and all other conditions pre-seeded, the
+merge binding evaluates true and the PlanItem transitions to RUNNING.
+
+## Dependency
+
+Add to `app/pom.xml` test scope (version from Quarkus BOM):
+
+```xml
+<dependency>
+  <groupId>org.awaitility</groupId>
+  <artifactId>awaitility</artifactId>
+  <scope>test</scope>
+</dependency>
+```
+
+## Key protocols honoured
+
+- **hitl-runtime-assembly**: work-adapter and blackboard already indexed (devtown#33) ✅
+- **yaml-humantask-binding-type**: `humanTask:` binding with `outputMapping` already in YAML ✅
+- **work-adapter-test-subcase-group-repository**: `MemorySubCaseGroupRepository` in `selected-alternatives` ✅
+- **quarkus-test-database**: H2, `test-port=0`, no `@TestTransaction` ✅
+- **GE-20260428-a67806**: `@ConsumeEvent(blocking = true)` already on `HumanTaskScheduleHandler` ✅
+
+## Out of scope
+
+- Testing WorkItem rejection or cancellation paths (separate issue if needed)
+- Testing the `human-approval` binding when `linesChanged <= threshold` (already
+  covered by `PrReviewBindingConditionTest.HumanApproval`)
+- HITL test for architecture-review or security-review gates (different binding types,
+  different issue)

--- a/docs/specs/2026-05-22-layer2-sla-breach-policy-design.md
+++ b/docs/specs/2026-05-22-layer2-sla-breach-policy-design.md
@@ -1,0 +1,308 @@
+# Design: Layer 2 — SLA-Bounded Human Review Gate with Escalation
+
+**Issue:** casehubio/devtown#38
+**Date:** 2026-05-22
+**Status:** Approved
+
+---
+
+## Problem
+
+Layer 1 gap comment in `NaivePrReviewService`:
+```java
+// LAYER 1 GAP: no response SLA — analysis can stall indefinitely with no escalation.
+```
+
+The `human-approval` binding in `pr-review.yaml` creates a WorkItem but sets no deadline, routes to no group, and has no domain-aware response when the deadline passes. A PR review can sit unclaimed forever with no observable consequence.
+
+---
+
+## What Layer 2 adds
+
+- Formal completion deadline on the human review WorkItem (`expiresIn` in YAML)
+- `candidateGroups` routing — who can claim the task
+- `SlaBreachPolicy` SPI — scope-aware, typed, chainable breach response
+- `SlaBreachHandler` — CDI observer that executes the policy when WorkItems expire
+- `pr-review.yaml` failure goal — case terminates with a named reason rather than stalling
+
+---
+
+## Module structure
+
+```
+casehubio/platform
+  apps-api/   (NEW — platform#24) pure Java SPI contracts: SlaBreachPolicy, BreachDecision,
+              BreachType, BreachedTask, SlaBreachContext
+  apps/       (NEW — platform#24) Quarkus: NoOpSlaBreachPolicy @ApplicationScoped @DefaultBean
+
+casehubio/devtown
+  devtown-domain/   SlaPreferenceKeys, StringPreference, IntPreference, DefaultSlaBreachPolicy
+  devtown-app/      SlaBreachHandler, SlaBreachPolicyBean (CDI wrapper)
+```
+
+`apps-api` depends on `platform-api` only (Path, Preferences, PreferenceKey). `devtown-domain` depends on `apps-api` and `platform-api`. `devtown-app` depends on `devtown-domain`, `casehub-work-runtime`, `casehub-engine-work-adapter`.
+
+**Sequencing:** `casehubio/platform` must ship `apps-api` and `apps` modules (platform#24) before devtown depends on them.
+
+---
+
+## SPI contract (in `platform/apps-api`)
+
+### BreachType
+
+```java
+public enum BreachType {
+    CLAIM_EXPIRED,       // nobody claimed within the claim deadline
+    COMPLETION_EXPIRED   // claimed but not completed within the completion deadline
+}
+```
+
+### BreachedTask
+
+Zero-dependency projection of `WorkItem` — `apps-api` never touches `casehub-work-runtime`:
+
+```java
+public record BreachedTask(
+    String taskId,
+    String callerRef,       // "case:{caseId}/pi:{planItemId}"
+    String title,
+    String candidateGroups  // CSV as stored in WorkItem
+) {}
+```
+
+### SlaBreachContext
+
+```java
+public record SlaBreachContext(
+    BreachType breachType,
+    BreachedTask task,
+    Path scope,             // resolved scope path — available for logging or further lookup
+    Preferences preferences // pre-resolved at Path.of("casehubio","devtown","pr-review",caseId)
+) {}
+```
+
+`Preferences` is pre-resolved by the framework so SPI implementations are pure Java — no CDI injection required.
+
+### BreachDecision
+
+Sealed, chainable. `EscalateTo` and `Extend` carry `thenOnBreach` — what the framework executes if the escalated or extended task also breaches:
+
+```java
+public sealed interface BreachDecision
+    permits BreachDecision.Fail, BreachDecision.EscalateTo, BreachDecision.Extend {
+
+    record Fail(String reason) implements BreachDecision {}
+
+    record EscalateTo(
+        String candidateGroup,
+        Duration deadline,
+        BreachDecision thenOnBreach
+    ) implements BreachDecision {}
+
+    record Extend(
+        Duration additionalTime,
+        BreachDecision thenOnBreach
+    ) implements BreachDecision {}
+}
+```
+
+A two-tier escalation chain:
+```java
+BreachDecision.escalateTo("pr-leads", Duration.ofHours(4),
+    new BreachDecision.Fail("sla-breach-final"))
+```
+
+### SlaBreachPolicy
+
+```java
+public interface SlaBreachPolicy {
+    BreachDecision onBreach(SlaBreachContext context);
+}
+```
+
+`NoOpSlaBreachPolicy` in `apps/` is `@ApplicationScoped @DefaultBean` — system is functional with no implementation wired.
+
+---
+
+## Scope-aware preference resolution
+
+Preferences resolve at `Path.of("casehubio", "devtown", "pr-review", caseId.toString())`.
+
+`JpaPreferenceProvider` walks ancestors: `["casehubio", "casehubio/devtown", "casehubio/devtown/pr-review", "casehubio/devtown/pr-review/<caseId>"]` — child overrides parent. This gives org → app → case-type → case-instance scope out of the box. RBAC on which level an actor may write to is a future concern (platform#6 persistence backend in place; write-side ACL not yet implemented).
+
+In tests, `MockPreferenceProvider` (`@DefaultBean`) is active. Values configured via `casehub.platform.preferences.defaults.devtown.sla.*` in `application.properties`.
+
+---
+
+## devtown-domain: SlaPreferenceKeys and DefaultSlaBreachPolicy
+
+```java
+public final class SlaPreferenceKeys {
+    public static final PreferenceKey<IntPreference> ESCALATION_HOURS =
+        new PreferenceKey<>("devtown.sla", "escalation-hours",
+            IntPreference.of(8), IntPreference::parse);
+    public static final PreferenceKey<StringPreference> ESCALATION_GROUP =
+        new PreferenceKey<>("devtown.sla", "escalation-group",
+            StringPreference.of("pr-leads"), StringPreference::parse);
+    public static final PreferenceKey<StringPreference> BREACH_TERMINAL_REASON =
+        new PreferenceKey<>("devtown.sla", "breach-terminal-reason",
+            StringPreference.of("sla-breach"), StringPreference::parse);
+    public static final PreferenceKey<IntPreference> COMPLETION_HOURS =
+        new PreferenceKey<>("devtown.sla", "completion-hours",
+            IntPreference.of(24), IntPreference::parse);
+    public static final PreferenceKey<StringPreference> CANDIDATE_GROUP =
+        new PreferenceKey<>("devtown.sla", "candidate-group",
+            StringPreference.of("pr-reviewers"), StringPreference::parse);
+}
+```
+
+`StringPreference` and `IntPreference` are simple records implementing `SingleValuePreference` — defined in `devtown-domain` alongside the keys.
+
+`DefaultSlaBreachPolicy` — pure Java, no CDI:
+```java
+public class DefaultSlaBreachPolicy implements SlaBreachPolicy {
+    @Override
+    public BreachDecision onBreach(SlaBreachContext ctx) {
+        Preferences p = ctx.preferences();
+        return new BreachDecision.EscalateTo(
+            p.getOrDefault(SlaPreferenceKeys.ESCALATION_GROUP).value(),
+            Duration.ofHours(p.getOrDefault(SlaPreferenceKeys.ESCALATION_HOURS).value()),
+            new BreachDecision.Fail(
+                p.getOrDefault(SlaPreferenceKeys.BREACH_TERMINAL_REASON).value()));
+    }
+}
+```
+
+CDI registration in `devtown-app`:
+```java
+@ApplicationScoped  // no @DefaultBean — displaces platform NoOpSlaBreachPolicy
+public class SlaBreachPolicyBean extends DefaultSlaBreachPolicy {}
+```
+
+---
+
+## SlaBreachHandler (devtown-app)
+
+```java
+@ApplicationScoped
+public class SlaBreachHandler {
+
+    @Inject SlaBreachPolicy slaBreachPolicy;
+    @Inject PreferenceProvider preferenceProvider;
+    @Inject PrReviewCaseHub caseHub;
+    @Inject WorkItemService workItemService;
+
+    void onExpiry(@ObservesAsync WorkItemLifecycleEvent event) {
+        if (!isBreachEvent(event)) return;
+        WorkItem item = (WorkItem) event.source();
+        if (!isManagedCallerRef(item.callerRef)) return;
+
+        UUID caseId = CallerRef.parse(item.callerRef).caseId();
+        BreachType breachType = toBreachType(event.eventType());
+        Preferences prefs = preferenceProvider.resolve(
+            SettingsScope.of("casehubio", "devtown", "pr-review", caseId.toString()));
+
+        BreachDecision decision = resolveDecision(item, prefs, breachType);
+        executeDecision(decision, caseId, item);
+    }
+}
+```
+
+**Filtering:** `isManagedCallerRef` accepts `callerRef != null && callerRef.startsWith("case:")` — only PR review WorkItems. Breach events: `EXPIRED` → `COMPLETION_EXPIRED`, `CLAIM_EXPIRED` → `CLAIM_EXPIRED`.
+
+**Decision resolution:** If the WorkItem carries a `breach-tier=terminal` label, the handler skips the policy and executes `Fail` directly using `SlaPreferenceKeys.BREACH_TERMINAL_REASON`. Otherwise calls `slaBreachPolicy.onBreach(ctx)`.
+
+**Decision execution:**
+
+| Decision | Action |
+|----------|--------|
+| `Fail(reason)` | `caseHub.signal(caseId, "humanApproval", Map.of("status", reason))` |
+| `EscalateTo(group, deadline, thenOnBreach)` | Create escalated WorkItem with new `candidateGroups`, `expiresAt = now + deadline`, same `callerRef`, label `breach-tier=terminal`. Signal case: `humanApproval.status = "escalating"` |
+| `Extend(duration, thenOnBreach)` | Requires `WorkItemService.extend()` — out of scope (work#211) |
+
+**Error handling:**
+
+| Condition | Response |
+|-----------|----------|
+| `callerRef` null or not a case ref | Log warn, return |
+| Case not found | Log warn, return |
+| `WorkItemService.create()` fails during `EscalateTo` | Log error, execute `Fail` directly |
+| `caseHub.signal()` throws | Log error — case won't terminate; known gap |
+
+---
+
+## pr-review.yaml changes
+
+Add `expiresIn` and `candidateGroups` to `human-approval` binding:
+```yaml
+- name: human-approval
+  on: { contextChange: {} }
+  when: ".pr.linesChanged > .policy.humanApprovalThreshold and .humanApproval == null"
+  humanTask:
+    title: "PR approval required"
+    candidateGroups: [pr-reviewers]
+    expiresIn: 24h
+    outputMapping: "{ humanApproval: . }"
+```
+
+Add failure goal (pending engine#326 — verify engine support):
+```yaml
+- name: pr-sla-breached
+  kind: failure
+  condition: >-
+    .humanApproval.status == "sla-breach" or
+    .humanApproval.status == "sla-breach-final"
+```
+
+If `kind: failure` is not yet supported, the case stalls on SLA breach (no merge possible) — acceptable for Layer 2; failure goal support tracked in engine#326.
+
+---
+
+## Testing
+
+### Unit — DefaultSlaBreachPolicy
+
+Plain JUnit, no Quarkus. Build `MapPreferences` directly. Cover:
+- `COMPLETION_EXPIRED` → returns `EscalateTo` with chained `Fail`
+- `CLAIM_EXPIRED` → appropriate decision
+- Default preference values with no overrides
+- `thenOnBreach` is a `Fail` with configured terminal reason
+
+### SPI wiring — SlaBreachHandlerWiringTest
+
+`@Alternative @ApplicationScoped` `CapturingBreachPolicy` records the `SlaBreachContext` delivered by the handler. Verifies scope path, breach type, and `BreachedTask` fields. Follows `spi-testing-alternative-inner-classes.md`.
+
+### Integration — SlaBreachLifecycleTest
+
+Full two-tier breach lifecycle as `@QuarkusTest`. Checkpoints:
+1. Start case (pre-seeded per PP-20260521-134c38)
+2. WorkItem created by `human-approval` binding
+3. Trigger expiry: set `WorkItem.expiresAt` to past, call `ExpiryLifecycleService.checkExpired()` directly
+4. Escalated WorkItem created (`candidateGroups=pr-leads`); case context `humanApproval.status = "escalating"`
+5. Trigger expiry on escalated WorkItem
+6. Case context `humanApproval.status = "sla-breach"`; no further WorkItems created
+
+Protocol compliance:
+- **PP-20260521-134c38** — pre-seed all parallel check keys
+- **PP-20260521-a36692** — `MemoryPlanItemStore` in `selected-alternatives`
+- **`scheduler-test-isolation.md`** — disable `ExpiryCleanupJob` in test properties
+
+---
+
+## Deferred concerns
+
+| Issue | What it unblocks |
+|-------|-----------------|
+| engine#325 — `HumanTaskTarget.claimDeadlineHours` | Declarative claim SLA in YAML |
+| engine#326 — failure goal support | Active case FAILED state on SLA breach |
+| engine#327 — dynamic `expiresIn` | Per-instance SLA thresholds from `PreferenceProvider` |
+| work#211 — `WorkItemService.extend()` | `BreachDecision.Extend` execution |
+| platform#24 — `apps-api` / `apps` modules | Prerequisite — must ship before devtown#38 implementation |
+
+---
+
+## What this closes
+
+Layer 1 gap: `// LAYER 1 GAP: no response SLA — analysis can stall indefinitely with no escalation.`
+
+After Layer 2: every PR review WorkItem has a formal deadline, routes to a named candidate group, and produces an observable case outcome on breach — either escalation to a senior group or case termination with a named reason.

--- a/docs/specs/2026-05-22-layer2-sla-breach-policy-design.md
+++ b/docs/specs/2026-05-22-layer2-sla-breach-policy-design.md
@@ -164,7 +164,7 @@ public class SlaBreachHandler {
 
     @Inject PrReviewCaseHub caseHub;
 
-    void onBreach(@ObservesAsync SlaBreachEvent event) {
+    void onBreach(@Observes SlaBreachEvent event) {
         CallerRef ref = CallerRef.parse(event.context().task().callerRef());
         if (ref == null) return;  // not a case-managed WorkItem
 

--- a/docs/specs/2026-05-22-layer2-sla-breach-policy-design.md
+++ b/docs/specs/2026-05-22-layer2-sla-breach-policy-design.md
@@ -1,7 +1,7 @@
 # Design: Layer 2 — SLA-Bounded Human Review Gate with Escalation
 
-**Issue:** casehubio/devtown#38
-**Date:** 2026-05-22
+**Issue:** casehubio/devtown#41
+**Date:** 2026-05-23 (reconciled from 2026-05-22 draft)
 **Status:** Approved
 
 ---
@@ -13,7 +13,9 @@ Layer 1 gap comment in `NaivePrReviewService`:
 // LAYER 1 GAP: no response SLA — analysis can stall indefinitely with no escalation.
 ```
 
-The `human-approval` binding in `pr-review.yaml` creates a WorkItem but sets no deadline, routes to no group, and has no domain-aware response when the deadline passes. A PR review can sit unclaimed forever with no observable consequence.
+The `human-approval` binding in `pr-review.yaml` creates a WorkItem but sets no deadline,
+routes to no group, and has no domain-aware response when the deadline passes. A PR review
+can sit unclaimed forever with no observable consequence.
 
 ---
 
@@ -21,120 +23,68 @@ The `human-approval` binding in `pr-review.yaml` creates a WorkItem but sets no 
 
 - Formal completion deadline on the human review WorkItem (`expiresIn` in YAML)
 - `candidateGroups` routing — who can claim the task
-- `SlaBreachPolicy` SPI — scope-aware, typed, chainable breach response
-- `SlaBreachHandler` — CDI observer that executes the policy when WorkItems expire
-- `pr-review.yaml` failure goal — case terminates with a named reason rather than stalling
+- `SlaBreachPolicy` SPI implementation in `devtown-domain` — scope-aware, stateless two-tier
+- `SlaBreachPolicyBean` in `devtown-app` — CDI displacement of `NoOpSlaBreachPolicy`
+- `SlaBreachHandler` in `devtown-app` — `SlaBreachEvent` observer that signals the case on Fail
+- `pr-review.yaml` — `candidateGroups` and `expiresIn` on `human-approval` binding
+
+---
+
+## SPI location (reconciled from draft)
+
+The draft assumed `SlaBreachPolicy`, `BreachDecision`, `SlaBreachContext`, `BreachType`, and
+`BreachedTask` would live in `casehub-platform/apps-api`. They shipped in `casehub-work-api`
+(pure Java, depends only on `casehub-platform-api`). `devtown-domain` can depend on
+`casehub-work-api` without violating its pure-Java tier constraint.
+
+`SlaBreachEvent` (`casehub-work-runtime`) carries the leaf `BreachDecision` that actually
+executed. Devtown observes this event — not `WorkItemLifecycleEvent` — to signal the case.
+
+---
+
+## Escalation mechanics (why no SlaBreachHandler on WorkItemLifecycleEvent)
+
+`ExpiryLifecycleService` already:
+1. Builds `SlaBreachContext` from the expired WorkItem
+2. Calls `slaBreachPolicy.onBreach(ctx)` — devtown's bean is the injected impl
+3. Executes the returned `BreachDecision`
+4. Fires `SlaBreachEvent(context, leafDecision)` for observers
+
+**EscalateTo path:** `executeEscalateTo` mutates the WorkItem in-place: `status = PENDING`,
+`candidateGroups = {escalation-group}`, new `expiresAt`. The "ESCALATED" lifecycle event fires
+with `workItem.status = PENDING`. `WorkItemLifecycleAdapter` ignores it (only handles
+COMPLETED/REJECTED/CANCELLED/EXPIRED/ESCALATED status values — PENDING is none of these).
+The PlanItem stays ACTIVE. The case waits. No CONTEXT_CHANGED fires from the adapter.
+
+**Fail path (second expiry):** `executeFail` sets `workItem.status = EXPIRED`,
+`workItem.resolution = fail.reason()` (plain string, not JSON). The "EXPIRED" lifecycle event
+fires. The adapter calls `item.markFaulted()` on the PlanItem and fires CONTEXT_CHANGED — but
+`applyOutputMapping` fails silently (resolution is not valid JSON) so the context is not updated.
+`SlaBreachEvent` fires. `SlaBreachHandler` observes it, extracts caseId from
+`callerRef` via `CallerRef.parse()`, and calls
+`caseHub.signal(caseId, "humanApproval", Map.of("status", fail.reason()))`.
+A second CONTEXT_CHANGED fires with the updated context. The failure goal evaluates.
 
 ---
 
 ## Module structure
 
 ```
-casehubio/platform
-  apps-api/   (NEW — platform#24) pure Java SPI contracts: SlaBreachPolicy, BreachDecision,
-              BreachType, BreachedTask, SlaBreachContext
-  apps/       (NEW — platform#24) Quarkus: NoOpSlaBreachPolicy @ApplicationScoped @DefaultBean
-
 casehubio/devtown
-  devtown-domain/   SlaPreferenceKeys, StringPreference, IntPreference, DefaultSlaBreachPolicy
-  devtown-app/      SlaBreachHandler, SlaBreachPolicyBean (CDI wrapper)
+  domain/pom.xml          add casehub-work-api dependency
+  domain/src/…/sla/
+    SlaPreferenceKeys       typed preference keys
+    DefaultSlaBreachPolicy  pure Java SlaBreachPolicy impl
+  app/src/…/
+    SlaBreachPolicyBean     @ApplicationScoped (no @DefaultBean) — displaces NoOpSlaBreachPolicy
+    SlaBreachHandler        @ApplicationScoped — observes SlaBreachEvent, signals case
 ```
 
-`apps-api` depends on `platform-api` only (Path, Preferences, PreferenceKey). `devtown-domain` depends on `apps-api` and `platform-api`. `devtown-app` depends on `devtown-domain`, `casehub-work-runtime`, `casehub-engine-work-adapter`.
-
-**Sequencing:** `casehubio/platform` must ship `apps-api` and `apps` modules (platform#24) before devtown depends on them.
+No new modules. No new SPIs. `review/` is unchanged.
 
 ---
 
-## SPI contract (in `platform/apps-api`)
-
-### BreachType
-
-```java
-public enum BreachType {
-    CLAIM_EXPIRED,       // nobody claimed within the claim deadline
-    COMPLETION_EXPIRED   // claimed but not completed within the completion deadline
-}
-```
-
-### BreachedTask
-
-Zero-dependency projection of `WorkItem` — `apps-api` never touches `casehub-work-runtime`:
-
-```java
-public record BreachedTask(
-    String taskId,
-    String callerRef,       // "case:{caseId}/pi:{planItemId}"
-    String title,
-    String candidateGroups  // CSV as stored in WorkItem
-) {}
-```
-
-### SlaBreachContext
-
-```java
-public record SlaBreachContext(
-    BreachType breachType,
-    BreachedTask task,
-    Path scope,             // resolved scope path — available for logging or further lookup
-    Preferences preferences // pre-resolved at Path.of("casehubio","devtown","pr-review",caseId)
-) {}
-```
-
-`Preferences` is pre-resolved by the framework so SPI implementations are pure Java — no CDI injection required.
-
-### BreachDecision
-
-Sealed, chainable. `EscalateTo` and `Extend` carry `thenOnBreach` — what the framework executes if the escalated or extended task also breaches:
-
-```java
-public sealed interface BreachDecision
-    permits BreachDecision.Fail, BreachDecision.EscalateTo, BreachDecision.Extend {
-
-    record Fail(String reason) implements BreachDecision {}
-
-    record EscalateTo(
-        String candidateGroup,
-        Duration deadline,
-        BreachDecision thenOnBreach
-    ) implements BreachDecision {}
-
-    record Extend(
-        Duration additionalTime,
-        BreachDecision thenOnBreach
-    ) implements BreachDecision {}
-}
-```
-
-A two-tier escalation chain:
-```java
-BreachDecision.escalateTo("pr-leads", Duration.ofHours(4),
-    new BreachDecision.Fail("sla-breach-final"))
-```
-
-### SlaBreachPolicy
-
-```java
-public interface SlaBreachPolicy {
-    BreachDecision onBreach(SlaBreachContext context);
-}
-```
-
-`NoOpSlaBreachPolicy` in `apps/` is `@ApplicationScoped @DefaultBean` — system is functional with no implementation wired.
-
----
-
-## Scope-aware preference resolution
-
-Preferences resolve at `Path.of("casehubio", "devtown", "pr-review", caseId.toString())`.
-
-`JpaPreferenceProvider` walks ancestors: `["casehubio", "casehubio/devtown", "casehubio/devtown/pr-review", "casehubio/devtown/pr-review/<caseId>"]` — child overrides parent. This gives org → app → case-type → case-instance scope out of the box. RBAC on which level an actor may write to is a future concern (platform#6 persistence backend in place; write-side ACL not yet implemented).
-
-In tests, `MockPreferenceProvider` (`@DefaultBean`) is active. Values configured via `casehub.platform.preferences.defaults.devtown.sla.*` in `application.properties`.
-
----
-
-## devtown-domain: SlaPreferenceKeys and DefaultSlaBreachPolicy
+## SlaPreferenceKeys
 
 ```java
 public final class SlaPreferenceKeys {
@@ -156,84 +106,86 @@ public final class SlaPreferenceKeys {
 }
 ```
 
-`StringPreference` and `IntPreference` are simple records implementing `SingleValuePreference` — defined in `devtown-domain` alongside the keys.
+`StringPreference` and `IntPreference` are records wrapping a single typed value and
+implementing `SingleValuePreference` — defined in `devtown-domain` alongside the keys.
+These are devtown's wrappers over the platform preference value type.
 
-`DefaultSlaBreachPolicy` — pure Java, no CDI:
+---
+
+## DefaultSlaBreachPolicy
+
+Pure Java, no CDI. Stateless two-tier escalation via `candidateGroups` inspection:
+
 ```java
 public class DefaultSlaBreachPolicy implements SlaBreachPolicy {
     @Override
     public BreachDecision onBreach(SlaBreachContext ctx) {
         Preferences p = ctx.preferences();
-        return new BreachDecision.EscalateTo(
-            p.getOrDefault(SlaPreferenceKeys.ESCALATION_GROUP).value(),
-            Duration.ofHours(p.getOrDefault(SlaPreferenceKeys.ESCALATION_HOURS).value()),
-            new BreachDecision.Fail(
-                p.getOrDefault(SlaPreferenceKeys.BREACH_TERMINAL_REASON).value()));
+        String escalationGroup = p.getOrDefault(SlaPreferenceKeys.ESCALATION_GROUP).value();
+        String terminalReason  = p.getOrDefault(SlaPreferenceKeys.BREACH_TERMINAL_REASON).value();
+        int    escalationHours = p.getOrDefault(SlaPreferenceKeys.ESCALATION_HOURS).value();
+
+        if (escalationGroup.isBlank()) {
+            return new BreachDecision.Fail("escalation-group-not-configured");
+        }
+        if (ctx.task().candidateGroups().contains(escalationGroup)) {
+            // Already escalated — this is the terminal breach
+            return new BreachDecision.Fail(terminalReason);
+        }
+        return EscalateTo.to(escalationGroup)
+                .withDeadline(Duration.ofHours(escalationHours));
     }
 }
 ```
 
-CDI registration in `devtown-app`:
-```java
-@ApplicationScoped  // no @DefaultBean — displaces platform NoOpSlaBreachPolicy
-public class SlaBreachPolicyBean extends DefaultSlaBreachPolicy {}
-```
+The stateless design: `candidateGroups` is the tier indicator. No state storage or decision
+serialization. See GE-20260522-f7db12.
 
 ---
 
-## SlaBreachHandler (devtown-app)
+## SlaBreachPolicyBean
+
+```java
+@ApplicationScoped  // no @DefaultBean — displaces casehub-work's NoOpSlaBreachPolicy
+public class SlaBreachPolicyBean extends DefaultSlaBreachPolicy {}
+```
+
+CDI displacement: `NoOpSlaBreachPolicy` in `casehub-work` is `@ApplicationScoped @DefaultBean`.
+This bean, lacking `@DefaultBean`, takes CDI priority and is the single active implementation.
+Follows the `@DefaultBean` displacement pattern used throughout devtown.
+
+---
+
+## SlaBreachHandler
 
 ```java
 @ApplicationScoped
 public class SlaBreachHandler {
 
-    @Inject SlaBreachPolicy slaBreachPolicy;
-    @Inject PreferenceProvider preferenceProvider;
     @Inject PrReviewCaseHub caseHub;
-    @Inject WorkItemService workItemService;
 
-    void onExpiry(@ObservesAsync WorkItemLifecycleEvent event) {
-        if (!isBreachEvent(event)) return;
-        WorkItem item = (WorkItem) event.source();
-        if (!isManagedCallerRef(item.callerRef)) return;
+    void onBreach(@ObservesAsync SlaBreachEvent event) {
+        CallerRef ref = CallerRef.parse(event.context().task().callerRef());
+        if (ref == null) return;  // not a case-managed WorkItem
 
-        UUID caseId = CallerRef.parse(item.callerRef).caseId();
-        BreachType breachType = toBreachType(event.eventType());
-        Preferences prefs = preferenceProvider.resolve(
-            SettingsScope.of("casehubio", "devtown", "pr-review", caseId.toString()));
-
-        BreachDecision decision = resolveDecision(item, prefs, breachType);
-        executeDecision(decision, caseId, item);
+        switch (event.decision()) {
+            case BreachDecision.Fail fail ->
+                caseHub.signal(ref.caseId(), "humanApproval",
+                    Map.of("status", fail.reason()));
+            default -> {}  // EscalateTo: WorkItem is in-place reassigned, case waits
+                           // Extend: deferred (work#211)
+        }
     }
 }
 ```
 
-**Filtering:** `isManagedCallerRef` accepts `callerRef != null && callerRef.startsWith("case:")` — only PR review WorkItems. Breach events: `EXPIRED` → `COMPLETION_EXPIRED`, `CLAIM_EXPIRED` → `CLAIM_EXPIRED`.
-
-**Decision resolution:** If the WorkItem carries a `breach-tier=terminal` label, the handler skips the policy and executes `Fail` directly using `SlaPreferenceKeys.BREACH_TERMINAL_REASON`. Otherwise calls `slaBreachPolicy.onBreach(ctx)`.
-
-**Decision execution:**
-
-| Decision | Action |
-|----------|--------|
-| `Fail(reason)` | `caseHub.signal(caseId, "humanApproval", Map.of("status", reason))` |
-| `EscalateTo(group, deadline, thenOnBreach)` | Create escalated WorkItem with new `candidateGroups`, `expiresAt = now + deadline`, same `callerRef`, label `breach-tier=terminal`. Signal case: `humanApproval.status = "escalating"` |
-| `Extend(duration, thenOnBreach)` | Requires `WorkItemService.extend()` — out of scope (work#211) |
-
-**Error handling:**
-
-| Condition | Response |
-|-----------|----------|
-| `callerRef` null or not a case ref | Log warn, return |
-| Case not found | Log warn, return |
-| `WorkItemService.create()` fails during `EscalateTo` | Log error, execute `Fail` directly |
-| `caseHub.signal()` throws | Log error — case won't terminate; known gap |
+`CallerRef` is from `casehub-engine-work-adapter` (already in `app/` deps).
+`caseHub.signal()` sets a path in the case context and fires CONTEXT_CHANGED internally.
 
 ---
 
 ## pr-review.yaml changes
 
-Add `expiresIn` and `candidateGroups` to `human-approval` binding:
 ```yaml
 - name: human-approval
   on: { contextChange: {} }
@@ -241,51 +193,54 @@ Add `expiresIn` and `candidateGroups` to `human-approval` binding:
   humanTask:
     title: "PR approval required"
     candidateGroups: [pr-reviewers]
-    expiresIn: 24h
+    expiresIn: PT24H
     outputMapping: "{ humanApproval: . }"
 ```
 
-Add failure goal (pending engine#326 — verify engine support):
+**Failure goal (deferred — engine#326):**
 ```yaml
 - name: pr-sla-breached
   kind: failure
-  condition: >-
-    .humanApproval.status == "sla-breach" or
-    .humanApproval.status == "sla-breach-final"
+  condition: '.humanApproval.status == "sla-breach"'
 ```
 
-If `kind: failure` is not yet supported, the case stalls on SLA breach (no merge possible) — acceptable for Layer 2; failure goal support tracked in engine#326.
+Without engine#326, the case stalls on SLA breach (merge binding condition requires
+`.humanApproval.status == "approved"` — never met). Acceptable for Layer 2; the case
+does not reach a false-positive success.
 
 ---
 
 ## Testing
 
-### Unit — DefaultSlaBreachPolicy
+### Unit — DefaultSlaBreachPolicyTest
 
-Plain JUnit, no Quarkus. Build `MapPreferences` directly. Cover:
-- `COMPLETION_EXPIRED` → returns `EscalateTo` with chained `Fail`
-- `CLAIM_EXPIRED` → appropriate decision
-- Default preference values with no overrides
-- `thenOnBreach` is a `Fail` with configured terminal reason
+Plain JUnit, no Quarkus. `MapPreferences` directly.
+- First breach (candidateGroups={pr-reviewers}): → `EscalateTo` to pr-leads, 8h deadline
+- Second breach (candidateGroups={pr-leads}): → `Fail("sla-breach")`
+- Blank escalation group configured: → `Fail("escalation-group-not-configured")`
+- Default preference values require no property override
 
 ### SPI wiring — SlaBreachHandlerWiringTest
 
-`@Alternative @ApplicationScoped` `CapturingBreachPolicy` records the `SlaBreachContext` delivered by the handler. Verifies scope path, breach type, and `BreachedTask` fields. Follows `spi-testing-alternative-inner-classes.md`.
+`@QuarkusTest`. `@Alternative @ApplicationScoped` `CapturingBreachPolicy` (static inner class,
+no `@DefaultBean`) captures `SlaBreachContext`. Verifies policy is injected by
+`ExpiryLifecycleService` and that bean displaces NoOp. Follows
+`spi-testing-alternative-inner-classes.md`.
 
 ### Integration — SlaBreachLifecycleTest
 
-Full two-tier breach lifecycle as `@QuarkusTest`. Checkpoints:
-1. Start case (pre-seeded per PP-20260521-134c38)
-2. WorkItem created by `human-approval` binding
-3. Trigger expiry: set `WorkItem.expiresAt` to past, call `ExpiryLifecycleService.checkExpired()` directly
-4. Escalated WorkItem created (`candidateGroups=pr-leads`); case context `humanApproval.status = "escalating"`
-5. Trigger expiry on escalated WorkItem
-6. Case context `humanApproval.status = "sla-breach"`; no further WorkItems created
+Full two-tier breach as `@QuarkusTest`. Pre-seeded per PP-20260521-134c38.
+`MemoryPlanItemStore` in `quarkus.arc.selected-alternatives` (PP-20260521-a36692).
+`ExpiryCleanupJob` disabled in test properties (scheduler-test-isolation.md).
 
-Protocol compliance:
-- **PP-20260521-134c38** — pre-seed all parallel check keys
-- **PP-20260521-a36692** — `MemoryPlanItemStore` in `selected-alternatives`
-- **`scheduler-test-isolation.md`** — disable `ExpiryCleanupJob` in test properties
+Checkpoints:
+1. Start PR review case with PR exceeding approval threshold
+2. WorkItem created by `human-approval` binding (candidateGroups=pr-reviewers)
+3. Set `expiresAt` to past; call `expiryService.checkExpired()`
+4. WorkItem mutated in-place: candidateGroups=pr-leads, status=PENDING, new expiresAt
+5. Case context unchanged (no CONTEXT_CHANGED with case signal fired yet)
+6. Set `expiresAt` to past again; call `expiryService.checkExpired()`
+7. Case context: `humanApproval.status == "sla-breach"` (via `SlaBreachHandler`)
 
 ---
 
@@ -293,11 +248,10 @@ Protocol compliance:
 
 | Issue | What it unblocks |
 |-------|-----------------|
-| engine#325 — `HumanTaskTarget.claimDeadlineHours` | Declarative claim SLA in YAML |
 | engine#326 — failure goal support | Active case FAILED state on SLA breach |
+| engine#325 — `HumanTaskTarget.claimDeadlineHours` | Declarative claim SLA in YAML |
 | engine#327 — dynamic `expiresIn` | Per-instance SLA thresholds from `PreferenceProvider` |
 | work#211 — `WorkItemService.extend()` | `BreachDecision.Extend` execution |
-| platform#24 — `apps-api` / `apps` modules | Prerequisite — must ship before devtown#38 implementation |
 
 ---
 
@@ -305,4 +259,6 @@ Protocol compliance:
 
 Layer 1 gap: `// LAYER 1 GAP: no response SLA — analysis can stall indefinitely with no escalation.`
 
-After Layer 2: every PR review WorkItem has a formal deadline, routes to a named candidate group, and produces an observable case outcome on breach — either escalation to a senior group or case termination with a named reason.
+After Layer 2: every PR review WorkItem has a formal deadline (24h), routes to `pr-reviewers`,
+escalates to `pr-leads` on breach, and signals the case context on terminal failure — observable
+and traceable from case history.

--- a/docs/specs/2026-05-25-sla-breach-handler-wiring-test-design.md
+++ b/docs/specs/2026-05-25-sla-breach-handler-wiring-test-design.md
@@ -66,7 +66,7 @@ void slaBreachHandler_onFail_signalsCaseContext() throws Exception {
     var task = new BreachedTask(UUID.randomUUID(), callerRef,
                                 "PR approval", Set.of("pr-leads"));
     var ctx  = new SlaBreachContext(BreachType.CLAIM_EXPIRED, task,
-                                    Path.root(), MapPreferences.empty());
+                                    Path.root(), new MapPreferences(Map.of()));
     breachEvents.fire(new SlaBreachEvent(ctx, new BreachDecision.Fail("sla-breach")));
 
     await().atMost(3, SECONDS).pollInterval(100, MILLISECONDS).untilAsserted(() -> {

--- a/docs/specs/2026-05-25-sla-breach-handler-wiring-test-design.md
+++ b/docs/specs/2026-05-25-sla-breach-handler-wiring-test-design.md
@@ -1,0 +1,149 @@
+# SlaBreachHandlerWiringTest — Design Spec
+
+**Issue:** casehubio/devtown#42
+**Date:** 2026-05-25
+
+---
+
+## Problem
+
+`SlaBreachLifecycleTest` covers the full SLA breach chain end-to-end, but a failure there
+can be caused by many things: WorkItem not created, YAML config wrong, expiry detection
+broken, two-tier escalation logic wrong, handler wiring broken. A focused wiring test gives
+faster, clearer failure messages specifically when CDI displacement breaks.
+
+---
+
+## What Needs Wiring Verification
+
+Two independent CDI concerns in devtown-app:
+
+1. **CDI displacement:** `SlaBreachPolicyBean @ApplicationScoped` (no `@DefaultBean`) must
+   displace `NoOpSlaBreachPolicy @DefaultBean @ApplicationScoped` from casehub-work-runtime.
+   If `SlaBreachPolicyBean` is absent or mis-annotated, the runtime's NoOp fires silently
+   without escalation.
+
+2. **Handler event routing:** `SlaBreachHandler @Observes SlaBreachEvent` must receive the
+   CDI event and call `PrReviewCaseHub.signal()` on `BreachDecision.Fail`. If the annotation
+   is removed, changed to `@ObservesAsync`, or the injection of `PrReviewCaseHub` fails,
+   the case is never signaled.
+
+---
+
+## Design
+
+Single `@QuarkusTest` class, two test methods. No `@Alternative` static inner classes,
+no `selected-alternatives` changes.
+
+### Test 1 — CDI displacement
+
+```java
+@Inject SlaBreachPolicy policy;
+
+@Test
+void slaBreachPolicyBean_displaces_noOp() {
+    assertThat(policy).isInstanceOf(SlaBreachPolicyBean.class);
+}
+```
+
+CDI resolves the `@Default` `SlaBreachPolicy` bean. `SlaBreachPolicyBean @ApplicationScoped`
+(no `@DefaultBean`) beats `NoOpSlaBreachPolicy @DefaultBean @ApplicationScoped`. If
+`SlaBreachPolicyBean` is missing or mis-annotated, this test fails at startup
+(`UnsatisfiedResolutionException`) or at assertion.
+
+### Test 2 — Handler wiring
+
+```java
+@Inject PrReviewCaseHub        caseHub;
+@Inject Event<SlaBreachEvent>  breachEvents;
+@Inject CaseInstanceRepository caseInstanceRepository;
+
+@Test
+void slaBreachHandler_onFail_signalsCaseContext() throws Exception {
+    UUID caseId = caseHub.startCase(MINIMAL_CTX).toCompletableFuture().get(5, SECONDS);
+
+    String callerRef = CallerRef.encode(caseId, "human-approval");
+    var task = new BreachedTask(UUID.randomUUID(), callerRef,
+                                "PR approval", Set.of("pr-leads"));
+    var ctx  = new SlaBreachContext(BreachType.CLAIM_EXPIRED, task,
+                                    Path.root(), MapPreferences.empty());
+    breachEvents.fire(new SlaBreachEvent(ctx, new BreachDecision.Fail("sla-breach")));
+
+    await().atMost(3, SECONDS).pollInterval(100, MILLISECONDS).untilAsserted(() -> {
+        var instance = caseInstanceRepository.findByUuid(caseId)
+                .await().atMost(Duration.ofSeconds(2));
+        assertThat(instance.getCaseContext().getPath("humanApproval.status"))
+                .isEqualTo("sla-breach");
+    });
+}
+```
+
+`SlaBreachEvent` is fired directly — `ExpiryLifecycleService` is bypassed entirely.
+`@Observes` (synchronous CDI) means the handler completes before `fire()` returns, but
+`caseHub.signal()` may trigger async engine writes, so `await` is kept.
+
+### Minimal context — why `linesChanged=100`
+
+`MINIMAL_CTX` uses `linesChanged=100` (below `humanApprovalThreshold=500`). With the
+pr-review YAML, this means all eight bindings are inactive when the case starts:
+
+- `codeAnalysis`, `ci`, `styleCheck`, `testCoverage`, `performanceAnalysis` are pre-seeded
+  (non-null) — suppresses those bindings (PP-20260521-134c38)
+- `securitySensitive=false`, `architectureCrossing=false` — suppresses those bindings
+- `linesChanged=100 ≤ 500=threshold` — suppresses `human-approval` binding
+
+No async binding activity after `startCase()` resolves. Case stays active because `pr-approved`
+goal requires `styleCheck.outcome == "APPROVED"` but it is `PENDING`.
+
+`signal(caseId, "humanApproval", ...)` works without an active plan item — the engine
+updates case context regardless. Confirmed by `HumanApprovalLifecycleTest` Checkpoint 5
+which signals `styleCheck`, `testCoverage`, `performanceAnalysis` (no corresponding
+WorkItems exist for those).
+
+### Why not CapturingBreachPolicy
+
+The issue describes a `CapturingBreachPolicy @Alternative @ApplicationScoped` approach.
+This approach is rejected because:
+
+1. `selected-alternatives` is build-time — `CapturingBreachPolicy` would displace
+   `SlaBreachPolicyBean` for every test in the file, making Test 1 impossible in the
+   same class.
+2. It tests `ExpiryLifecycleService → SlaBreachPolicy` dispatch — a casehub-work concern
+   already covered by `SlaBreachLifecycleTest` Checkpoints 3–4.
+3. It introduces a race condition: driving through `ExpiryLifecycleService` requires
+   `linesChanged=600 > threshold`, which fires the `human-approval` binding
+   asynchronously.
+
+### Failure modes caught
+
+| Failure | How caught |
+|---|---|
+| `SlaBreachPolicyBean` absent | Startup `UnsatisfiedResolutionException` |
+| `@ApplicationScoped` annotation missing | Startup failure |
+| `@Observes` changed to `@ObservesAsync` | Test 2 times out — event not received synchronously |
+| `@Inject PrReviewCaseHub` fails | Startup failure |
+| `switch` on `Fail` removed or wrong key | Test 2 times out — case context not updated |
+
+### Out of scope
+
+- Two-tier escalation logic → `DefaultSlaBreachPolicyTest` (domain unit test)
+- Full expiry detection chain → `SlaBreachLifecycleTest`
+- `humanApprovalThreshold` as a Preference rather than case-context field — separate issue
+  if desired; requires changes to the YAML binding and case context population
+
+---
+
+## File Location
+
+`app/src/test/java/io/casehub/devtown/app/SlaBreachHandlerWiringTest.java`
+
+No changes to `application.properties` — no new `selected-alternatives` entries.
+
+---
+
+## Protocol Compliance
+
+Follows `spi-testing-alternative-inner-classes.md` intent: test doubles are the pattern
+for SPI wiring tests. Here, no `@Alternative` is needed because we fire the CDI event
+directly rather than driving through the SPI caller. GE-20260512-c246b0 warnings about
+`selected-alternatives` pitfalls are avoided entirely.

--- a/docs/squash-plan-2026-05-23.md
+++ b/docs/squash-plan-2026-05-23.md
@@ -1,0 +1,271 @@
+# Squash Plan — upstream/main..HEAD (2026-05-23)
+
+50 commits → 18 commits. 32 absorbed, 0 dropped.
+Working branch: squash/wip-main-20260523-014850
+
+---
+
+## Group 1 — Epic 2 baseline
+*2 commits → 1*
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `8b3305e` refactor(domain): promote CapabilityRegistry.isKnown to SPI default method | ✅ KEEP | *(message adequate — unchanged)* |
+| `e35f267` build(deps): bump assertj-core from 3.24.2 to 3.27.7 | 🔽 SQUASH ↑ | *(absorbed — small dep bump, same-session, no issue ref)* |
+
+> **Result:** 1 commit.
+
+---
+
+## Group 2 — CLAUDE.md initial setup
+*3 commits → 1*
+**Final message:** `docs(claude): add Git Discipline section, design doc convention, and artifact routing`
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `e1f4139` docs(claude): add Git Discipline section — workspace/project repo split | ✅ KEEP | *(see Final message above)* |
+| `da9b4cd` docs(claude): fix artifact routing — adr/blog/specs → project, design/snapshots/handover → workspace | 🔽 SQUASH ↑ | *(absorbed — routing fixup, same CLAUDE.md concern)* |
+| `4b19bcb` docs(claude): add design doc convention + complete workflow chain | 🔽 SQUASH ↑ | *(absorbed — CLAUDE.md addendum, same session)* |
+
+> **Result:** 1 commit.
+
+---
+
+## Group 3 — Contributor trust proposal
+*1 commit → 1 (already standalone)*
+
+✅ KEEP `1773673` docs: add contributor trust TL;DR proposal (devtown#24)
+
+> **Result:** 1 commit.
+
+---
+
+## Group 4 — Agentic harness docs
+*2 commits → 1*
+**Final message:** `docs: add agentic harness goals, LAYER-LOG.md obligation, reference docs, and portable paths`
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `2a8bc7f` docs: add agentic harness goals, LAYER-LOG.md obligation, and reference docs | ✅ KEEP | *(see Final message above)* |
+| `99f425b` docs: replace machine-specific paths with relative peer paths | 🔽 SQUASH ↑ | *(absorbed — stale-ref fixup on same docs; 2a8bc7f introduced the paths that needed fixing)* |
+
+> **Result:** 1 commit.
+
+---
+
+## Group 5 — Design spec promotions
+*1 commit → 1 (standalone)*
+
+✅ KEEP `3747999` docs: promote Epic 1 and Epic 2 design specs to project repo
+
+> **Result:** 1 commit.
+
+---
+
+## Group 6 — LAYER-LOG setup
+*5 commits → 1*
+**Final message:** `docs: add retroactive LAYER-LOG.md — Layers 1–7 with protocol fixes and CLAUDE.md routing alignment`
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `3777716` docs: add retroactive LAYER-LOG.md — Layers 1-7 with placeholders | ✅ KEEP | *(see Final message above)* |
+| `7491420` docs(claude): clarify LAYER-LOG.md — epics≠layers, incremental entries | 🔽 SQUASH ↑ | *(absorbed — immediate clarification of same commit)* |
+| `cb3ca2c` docs: remove unstarted layer skeleton entries from LAYER-LOG.md | 🔽 SQUASH ↑ | *(absorbed — cleanup of same LAYER-LOG commit)* |
+| `2268d87` docs: apply four protocol fixes to LAYER-LOG.md | 🔽 SQUASH ↑ | *(absorbed — protocol fixups on same document)* |
+| `4a5fa6b` fix(claude): standardise routing table — adr/specs→project, blog→workspace→mdproctor.github.io | 🔽 SQUASH ↑ | *(absorbed — CLAUDE.md routing stabilisation, same session)* |
+
+> **Result:** 1 commit.
+
+---
+
+## Group 7 — Layer 1 Part B: naive service
+*4 commits → 1*
+**Final message:** `feat(app): Layer 1 Part B — naive PR review service, gap comments, LAYER-LOG entry`
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `cca6acc` feat(app): Layer 1 Part B — naive PR review service with gap comments | ✅ KEEP | *(see Final message above)* |
+| `1c6921f` docs(specs): Layer 1 Part B naive service design spec | 🔽 SQUASH ↑ | *(absorbed — pre-implementation spec for this feat)* |
+| `1fa95ce` docs(layer-log): complete Layer 1 Part B entry; add Layer 5 stub | 🔽 SQUASH ↑ | *(absorbed — LAYER-LOG entry for this exact layer)* |
+| `18b22e0` refactor(review): move PrReviewApplicationService and DTOs to review module | 🔀 MERGE ↑ | *(merged — same Layer 1 Part B scope; SPI moved from app to review as part of the same structural decision)* |
+
+> **Result:** 1 commit.
+
+---
+
+## Group 8 — PrReviewResource dispatcher
+*1 commit → 1 (standalone)*
+
+✅ KEEP `2944072` feat(app): PrReviewResource — POST /api/reviews dispatcher
+
+> **Result:** 1 commit.
+
+---
+
+## Group 9 — PR review CasePlanModel YAML (Epic 3 core)
+*3 commits → 1*
+**Final message:** `feat(review): PR review CasePlanModel YAML — 9 bindings, 3 goals, casehub-engine dep`
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `d8a70d9` feat(review): PR review CasePlanModel YAML — 9 bindings, 3 goals | ✅ KEEP | *(see Final message above)* |
+| `a5e21bf` docs(specs): Epic 3 PR review CasePlanModel design spec | 🔽 SQUASH ↑ | *(absorbed — pre-implementation spec)* |
+| `ae55054` build(app): add casehub-engine runtime dep for YamlCaseHub | 🔽 SQUASH ↑ | *(absorbed — build dep required by this feat; < 5 lines)* |
+
+> **Result:** 1 commit.
+
+---
+
+## Group 10 — PrReviewCaseHub service (Epic 3 wiring)
+*5 commits → 1*
+**Final message:** `feat(app): PrReviewCaseHub and PrReviewCaseService — displaces naive impl`
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `85efe5c` feat(app): PrReviewCaseHub and PrReviewCaseService — displaces naive impl | ✅ KEEP | *(message adequate — unchanged)* |
+| `445d6fd` fix(app): remove duplicate pr-review.yaml from app resources | 🔽 SQUASH ↑ | *(absorbed — < 5 lines, cleanup artifact from this feat)* |
+| `36cd91b` fix(app): quality fixes from code review — document startCase discard, implement findLatestBySubjectId | 🔽 SQUASH ↑ | *(absorbed — post-review fixups on this feat)* |
+| `b65ccb9` test(app): YAML round-trip @QuarkusTest for PrReviewCaseHub | 🔽 SQUASH ↑ | *(absorbed — integration test for this exact class)* |
+| `d9499d7` docs(layer-log): complete Layer 5 entry — Epic 3 shipped | 🔽 SQUASH ↑ | *(absorbed — LAYER-LOG entry for this layer)* |
+
+> **Result:** 1 commit.
+
+---
+
+## Group 11 — Binding condition unit tests (TDD)
+*3 commits → 1*
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `098fc92` test(review): 27 binding condition unit tests — TDD, pure unit, no Quarkus | ✅ KEEP | *(message adequate — unchanged)* |
+| `81cfdc4` fix(review): merge binding missing securitySensitive conditional | 🔽 SQUASH ↑ | *(absorbed — test-driven fix for this test suite)* |
+| `a7003b4` fix(review): pr-approved goal missing securitySensitive conditional | 🔽 SQUASH ↑ | *(absorbed — same; both are corrections discovered by 098fc92 tests)* |
+
+> **Result:** 1 commit.
+
+---
+
+## Group 12 — CLAUDE.md / layer-log docs + contrib trust spec (Epic 3 close)
+*3 commits → 1 (SQUASH into nearest KEEP)*
+⚠️ **Proximity-grouped** — these docs commits are absorbed into d8a70d9 as the nearest meaningful KEEP for the Epic 3 close period.
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `b79fec6` docs(claude): add Epic 3 and parent#26 to foundation gates | 🔽 SQUASH ↑ `d8a70d9` | *(absorbed — CLAUDE.md update recording Epic 3 complete)* |
+| `0f70697` docs(specs): promote contributor trust open source spec | 🔽 SQUASH ↑ `d8a70d9` | *(absorbed — spec file copy, < 5 lines effective)* |
+
+---
+
+## Group 13 — PrFinding and PrVerdict (Layer 1 API stability)
+*2 commits → 1*
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `47e2266` feat(review): introduce PrFinding and PrVerdict for Layer 1 API stability | ✅ KEEP | *(message adequate — unchanged)* |
+| `d0bfdfa` test(review): add missing doesNotFire_whenAnalysisNotComplete tests and use method references | 🔽 SQUASH ↑ | *(absorbed — test additions for the same feat; < 5 lines effective change)* |
+
+> **Result:** 1 commit.
+
+---
+
+## Group 14 — NaivePrReviewService fixture + PrReviewResource integration test
+*1 commit → 1 (standalone)*
+
+✅ KEEP `f687e5f` test(app): extract NaivePrReviewService fixture and add PrReviewResource integration test
+
+> **Result:** 1 commit.
+
+---
+
+## Group 15 — HITL work-adapter wiring (devtown#33)
+*5 commits → 1*
+**Final message:** `feat: wire casehub-engine-work-adapter for HITL case resumption (Closes #33)`
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `e4830ea` feat: wire casehub-engine-work-adapter for HITL case resumption | ✅ KEEP | *(see Final message above)* |
+| `448e05b` chore: add DESIGN.md stub — Refs casehubio/parent#31 | 🔽 SQUASH ↑ | *(absorbed — tiny chore, < 5 lines)* |
+| `e4e2a86` docs: clarify selected-alternatives build-time semantics (engine#293) | 🔽 SQUASH ↑ | *(absorbed — docs clarification triggered by this wiring work)* |
+| `ec610d3` docs(CLAUDE.md): mark HITL wiring complete — devtown#33 done, devtown#30 unblocked | 🔽 SQUASH ↑ | *(absorbed — CLAUDE.md status update for this feat)* |
+| `a0f0fc7` feat: wire casehub-engine-work-adapter for HITL case resumption (closes #33) | 🔽 SQUASH (merge commit) | *(local topic merge — consolidates 448e05b + ec610d3; content already captured in absorbed commits)* |
+
+> **Result:** 1 commit.
+
+---
+
+## Group 16 — HITL e2e integration test (devtown#30)
+*3 commits → 1*
+**Final message:** `test(app): HITL end-to-end integration test for human approval binding (Closes #30)`
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `3271d8f` test(app): HITL end-to-end integration test for human approval binding (devtown#30) | ✅ KEEP | *(see Final message above)* |
+| `067da9f` protocol(PP-20260521-134c38, PP-20260521-a36692): HITL test context pre-seeding and MemoryPlanItemStore selection | 🔽 SQUASH ↑ | *(absorbed — protocol doc commit accompanying this test)* |
+| `a44190a` feat(docs): promote HITL human approval lifecycle spec from issue-30-hitl-human-approval-test | 🔽 SQUASH ↑ | *(absorbed — spec file copy tied to this test work)* |
+
+> **Result:** 1 commit.
+
+---
+
+## Group 17 — Protocol path refactor + CLAUDE.md/LAYER-LOG alignment
+*2 commits → SQUASH into Group 16*
+⚠️ **Proximity-grouped** — no standalone feature; absorbed into nearest KEEP.
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `e7c9a47` refactor(docs): update protocol paths to casehub/garden | 🔽 SQUASH ↑ `3271d8f` | *(absorbed — stale-ref fixup on protocol paths)* |
+| `84dce53` docs: align CLAUDE.md and LAYER-LOG.md with AML tutorial-layer discipline | 🔽 SQUASH ↑ `f53899a` | *(absorbed — CLAUDE.md/LAYER-LOG alignment, nearest KEEP is Layer 2 spec)* |
+
+---
+
+## Group 18 — Layer 2 SLA spec + CDI fix (issue-38)
+*4 commits → 2*
+
+### 18a — Layer 2 SLA breach policy spec
+**Final message:** `docs(specs): Layer 2 SLA breach policy design — protocols and CLAUDE.md update (Refs #38)`
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `f53899a` docs(specs): Layer 2 SLA breach policy design — devtown#38 | ✅ KEEP | *(see Final message above)* |
+| `c52d308` protocol(PP-20260522-fe93b6, PP-20260522-f08b62): cross-repo state verification + transactional loop exception safety | 🔽 SQUASH ↑ | *(absorbed — protocol docs accompanying the Layer 2 design work)* |
+| `1b13586` docs(CLAUDE.md): flag Path.root() pending + transactional loop protocol ref | 🔽 SQUASH ↑ | *(absorbed — CLAUDE.md update tied to Layer 2 design)* |
+
+### 18b — CDI deployment fix
+**Final message:** `fix(build): resolve non-persistence CDI deployment problems (Closes #31, Refs #39)`
+
+| Commit | Action | Curated result |
+|--------|--------|----------------|
+| `3e4f22f` fix(build): resolve non-persistence CDI deployment problems (Closes #31) | ✅ KEEP | *(see Final message above)* |
+| `19543c4` chore: add casehub-platform-api compile dep and casehub-platform-testing test dep to devtown-app (devtown#39) | 🔽 SQUASH ↑ | *(absorbed — pre-existing gap fix that enabled the CDI work; Refs #39 added to curated message)* |
+
+> **Result:** 2 commits.
+
+---
+
+## AFTER — what `git log --oneline` will show (estimated)
+
+```
+  50  commits (original)
+  -32  absorbed by squash
+  ──────────────────────────────────────────
+  18  commits — no content lost
+
+Estimated sample (most recent → oldest):
+  fix(build): resolve non-persistence CDI deployment problems (Closes #31, Refs #39)
+  docs(specs): Layer 2 SLA breach policy design — protocols and CLAUDE.md update (Refs #38)
+  test(app): HITL end-to-end integration test for human approval binding (Closes #30)
+  feat: wire casehub-engine-work-adapter for HITL case resumption (Closes #33)
+  test(app): extract NaivePrReviewService fixture and add PrReviewResource integration test
+  feat(review): introduce PrFinding and PrVerdict for Layer 1 API stability
+  test(review): 27 binding condition unit tests — TDD, pure unit, no Quarkus
+  feat(app): PrReviewCaseHub and PrReviewCaseService — displaces naive impl
+  feat(review): PR review CasePlanModel YAML — 9 bindings, 3 goals, casehub-engine dep
+  feat(app): PrReviewResource — POST /api/reviews dispatcher
+  feat(app): Layer 1 Part B — naive PR review service, gap comments, LAYER-LOG entry
+  docs: add retroactive LAYER-LOG.md — Layers 1–7 with protocol fixes and CLAUDE.md routing alignment
+  docs: promote Epic 1 and Epic 2 design specs to project repo
+  docs: add agentic harness goals, LAYER-LOG.md obligation, reference docs, and portable paths
+  docs: add contributor trust TL;DR proposal (devtown#24)
+  docs(claude): add Git Discipline section, design doc convention, and artifact routing
+  refactor(domain): promote CapabilityRegistry.isKnown to SPI default method
+```

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -16,6 +16,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.casehub</groupId>
+      <artifactId>casehub-work-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.casehub</groupId>
+      <artifactId>casehub-platform-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/domain/src/main/java/io/casehub/devtown/domain/sla/DefaultSlaBreachPolicy.java
+++ b/domain/src/main/java/io/casehub/devtown/domain/sla/DefaultSlaBreachPolicy.java
@@ -1,0 +1,26 @@
+package io.casehub.devtown.domain.sla;
+
+import io.casehub.work.api.BreachDecision;
+import io.casehub.work.api.SlaBreachContext;
+import io.casehub.work.api.SlaBreachPolicy;
+import java.time.Duration;
+
+public class DefaultSlaBreachPolicy implements SlaBreachPolicy {
+
+    @Override
+    public BreachDecision onBreach(SlaBreachContext ctx) {
+        var p = ctx.preferences();
+        var escalationGroup = p.getOrDefault(SlaPreferenceKeys.ESCALATION_GROUP).value();
+        var terminalReason  = p.getOrDefault(SlaPreferenceKeys.BREACH_TERMINAL_REASON).value();
+        int escalationHours = p.getOrDefault(SlaPreferenceKeys.ESCALATION_HOURS).value();
+
+        if (escalationGroup.isBlank()) {
+            return new BreachDecision.Fail("escalation-group-not-configured");
+        }
+        if (ctx.task().candidateGroups().contains(escalationGroup)) {
+            return new BreachDecision.Fail(terminalReason);
+        }
+        return BreachDecision.EscalateTo.to(escalationGroup)
+                .withDeadline(Duration.ofHours(escalationHours));
+    }
+}

--- a/domain/src/main/java/io/casehub/devtown/domain/sla/IntPreference.java
+++ b/domain/src/main/java/io/casehub/devtown/domain/sla/IntPreference.java
@@ -1,0 +1,12 @@
+package io.casehub.devtown.domain.sla;
+
+import io.casehub.platform.api.preferences.SingleValuePreference;
+import java.util.Objects;
+
+public record IntPreference(int value) implements SingleValuePreference {
+    public static IntPreference of(int value) { return new IntPreference(value); }
+    public static IntPreference parse(String raw) {
+        Objects.requireNonNull(raw, "raw must not be null");
+        return new IntPreference(Integer.parseInt(raw));
+    }
+}

--- a/domain/src/main/java/io/casehub/devtown/domain/sla/SlaPreferenceKeys.java
+++ b/domain/src/main/java/io/casehub/devtown/domain/sla/SlaPreferenceKeys.java
@@ -20,9 +20,5 @@ public final class SlaPreferenceKeys {
         new PreferenceKey<>("devtown.sla", "completion-hours",
             IntPreference.of(24), IntPreference::parse);
 
-    public static final PreferenceKey<StringPreference> CANDIDATE_GROUP =
-        new PreferenceKey<>("devtown.sla", "candidate-group",
-            StringPreference.of("pr-reviewers"), StringPreference::parse);
-
     private SlaPreferenceKeys() {}
 }

--- a/domain/src/main/java/io/casehub/devtown/domain/sla/SlaPreferenceKeys.java
+++ b/domain/src/main/java/io/casehub/devtown/domain/sla/SlaPreferenceKeys.java
@@ -1,0 +1,28 @@
+package io.casehub.devtown.domain.sla;
+
+import io.casehub.platform.api.preferences.PreferenceKey;
+
+public final class SlaPreferenceKeys {
+
+    public static final PreferenceKey<IntPreference> ESCALATION_HOURS =
+        new PreferenceKey<>("devtown.sla", "escalation-hours",
+            IntPreference.of(8), IntPreference::parse);
+
+    public static final PreferenceKey<StringPreference> ESCALATION_GROUP =
+        new PreferenceKey<>("devtown.sla", "escalation-group",
+            StringPreference.of("pr-leads"), StringPreference::parse);
+
+    public static final PreferenceKey<StringPreference> BREACH_TERMINAL_REASON =
+        new PreferenceKey<>("devtown.sla", "breach-terminal-reason",
+            StringPreference.of("sla-breach"), StringPreference::parse);
+
+    public static final PreferenceKey<IntPreference> COMPLETION_HOURS =
+        new PreferenceKey<>("devtown.sla", "completion-hours",
+            IntPreference.of(24), IntPreference::parse);
+
+    public static final PreferenceKey<StringPreference> CANDIDATE_GROUP =
+        new PreferenceKey<>("devtown.sla", "candidate-group",
+            StringPreference.of("pr-reviewers"), StringPreference::parse);
+
+    private SlaPreferenceKeys() {}
+}

--- a/domain/src/main/java/io/casehub/devtown/domain/sla/StringPreference.java
+++ b/domain/src/main/java/io/casehub/devtown/domain/sla/StringPreference.java
@@ -1,0 +1,13 @@
+package io.casehub.devtown.domain.sla;
+
+import io.casehub.platform.api.preferences.SingleValuePreference;
+import java.util.Objects;
+
+public record StringPreference(String value) implements SingleValuePreference {
+    public StringPreference {
+        Objects.requireNonNull(value, "value must not be null");
+    }
+    public static StringPreference of(String value) { return new StringPreference(value); }
+    // parse is the Function<String,T> reference used by PreferenceKey; identical to of() for strings
+    public static StringPreference parse(String raw) { return new StringPreference(raw); }
+}

--- a/domain/src/main/java/io/casehub/devtown/domain/sla/StringPreference.java
+++ b/domain/src/main/java/io/casehub/devtown/domain/sla/StringPreference.java
@@ -9,5 +9,8 @@ public record StringPreference(String value) implements SingleValuePreference {
     }
     public static StringPreference of(String value) { return new StringPreference(value); }
     // parse is the Function<String,T> reference used by PreferenceKey; identical to of() for strings
-    public static StringPreference parse(String raw) { return new StringPreference(raw); }
+    public static StringPreference parse(String raw) {
+        Objects.requireNonNull(raw, "raw must not be null");
+        return new StringPreference(raw);
+    }
 }

--- a/domain/src/test/java/io/casehub/devtown/domain/sla/DefaultSlaBreachPolicyTest.java
+++ b/domain/src/test/java/io/casehub/devtown/domain/sla/DefaultSlaBreachPolicyTest.java
@@ -1,0 +1,101 @@
+package io.casehub.devtown.domain.sla;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.platform.api.path.Path;
+import io.casehub.platform.api.preferences.MapPreferences;
+import io.casehub.platform.api.preferences.Preferences;
+import io.casehub.work.api.BreachDecision;
+import io.casehub.work.api.BreachType;
+import io.casehub.work.api.BreachedTask;
+import io.casehub.work.api.SlaBreachContext;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class DefaultSlaBreachPolicyTest {
+
+    private final DefaultSlaBreachPolicy policy = new DefaultSlaBreachPolicy();
+
+    @Test
+    void firstBreach_escalatesToDefaultEscalationGroup() {
+        var ctx = ctx(Set.of("pr-reviewers"), defaultPrefs());
+        var decision = policy.onBreach(ctx);
+        assertThat(decision).isInstanceOf(BreachDecision.EscalateTo.class);
+        var escalate = (BreachDecision.EscalateTo) decision;
+        assertThat(escalate.groups()).containsExactly("pr-leads");
+    }
+
+    @Test
+    void firstBreach_deadlineIsEscalationHours() {
+        var ctx = ctx(Set.of("pr-reviewers"), defaultPrefs());
+        var decision = (BreachDecision.EscalateTo) policy.onBreach(ctx);
+        assertThat(decision.deadline()).isEqualTo(Duration.ofHours(8));
+    }
+
+    @Test
+    void firstBreach_claimExpiredAlsoEscalates() {
+        var ctx = ctxType(BreachType.CLAIM_EXPIRED, Set.of("pr-reviewers"), defaultPrefs());
+        assertThat(policy.onBreach(ctx)).isInstanceOf(BreachDecision.EscalateTo.class);
+    }
+
+    @Test
+    void secondBreach_failsWithTerminalReason() {
+        var ctx = ctx(Set.of("pr-leads"), defaultPrefs());
+        var decision = policy.onBreach(ctx);
+        assertThat(decision).isInstanceOf(BreachDecision.Fail.class);
+        assertThat(((BreachDecision.Fail) decision).reason()).isEqualTo("sla-breach");
+    }
+
+    @Test
+    void secondBreach_withCustomTerminalReason() {
+        var prefs = new MapPreferences(
+            Map.of("devtown.sla.breach-terminal-reason", "custom-breach-reason"));
+        var ctx = ctx(Set.of("pr-leads"), prefs);
+        var decision = (BreachDecision.Fail) policy.onBreach(ctx);
+        assertThat(decision.reason()).isEqualTo("custom-breach-reason");
+    }
+
+    @Test
+    void customEscalationGroup_usedForBothTierDetectionAndEscalation() {
+        var prefs = new MapPreferences(Map.of("devtown.sla.escalation-group", "senior-leads"));
+        var ctx1 = ctx(Set.of("pr-reviewers"), prefs);
+        assertThat(policy.onBreach(ctx1)).isInstanceOf(BreachDecision.EscalateTo.class);
+        assertThat(((BreachDecision.EscalateTo) policy.onBreach(ctx1)).groups())
+            .containsExactly("senior-leads");
+
+        var ctx2 = ctx(Set.of("senior-leads"), prefs);
+        assertThat(policy.onBreach(ctx2)).isInstanceOf(BreachDecision.Fail.class);
+    }
+
+    @Test
+    void customEscalationHours_appliedToDeadline() {
+        var prefs = new MapPreferences(Map.of("devtown.sla.escalation-hours", "4"));
+        var ctx = ctx(Set.of("pr-reviewers"), prefs);
+        var decision = (BreachDecision.EscalateTo) policy.onBreach(ctx);
+        assertThat(decision.deadline()).isEqualTo(Duration.ofHours(4));
+    }
+
+    @Test
+    void blankEscalationGroup_returnsSafeFail() {
+        var prefs = new MapPreferences(Map.of("devtown.sla.escalation-group", ""));
+        var ctx = ctx(Set.of("pr-reviewers"), prefs);
+        var decision = (BreachDecision.Fail) policy.onBreach(ctx);
+        assertThat(decision.reason()).isEqualTo("escalation-group-not-configured");
+    }
+
+    private static Preferences defaultPrefs() {
+        return new MapPreferences(Map.of());
+    }
+
+    private static SlaBreachContext ctx(Set<String> groups, Preferences prefs) {
+        return ctxType(BreachType.COMPLETION_EXPIRED, groups, prefs);
+    }
+
+    private static SlaBreachContext ctxType(BreachType type, Set<String> groups, Preferences prefs) {
+        var task = new BreachedTask(UUID.randomUUID(), "case:x/pi:y", "PR review", groups);
+        return new SlaBreachContext(type, task, Path.root(), prefs);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,21 @@
         <version>${casehub.version}</version>
       </dependency>
 
+      <!-- casehub-engine-testing — annotated in-memory SPI impls for @QuarkusTest -->
+      <dependency>
+        <groupId>io.casehub</groupId>
+        <artifactId>casehub-engine-testing</artifactId>
+        <version>${casehub.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- casehub-engine-scheduler-quartz — JobScheduler + WorkerExecutionManager SPI impls -->
+      <dependency>
+        <groupId>io.casehub</groupId>
+        <artifactId>casehub-engine-scheduler-quartz</artifactId>
+        <version>${casehub.version}</version>
+      </dependency>
+
       <!-- casehub-qhorus-api — not in casehub-parent BOM -->
       <dependency>
         <groupId>io.casehub</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,21 @@
         <version>${casehub.version}</version>
       </dependency>
 
+      <!-- casehub-engine-work-adapter — bridge between WorkItemLifecycleEvent and PlanItem -->
+      <dependency>
+        <groupId>io.casehub</groupId>
+        <artifactId>casehub-engine-work-adapter</artifactId>
+        <version>${casehub.version}</version>
+      </dependency>
+
+      <!-- casehub-engine-persistence-memory — in-memory SPI impls including SubCaseGroupRepository -->
+      <dependency>
+        <groupId>io.casehub</groupId>
+        <artifactId>casehub-engine-persistence-memory</artifactId>
+        <version>${casehub.version}</version>
+        <scope>test</scope>
+      </dependency>
+
       <!-- casehub-qhorus-api — not in casehub-parent BOM -->
       <dependency>
         <groupId>io.casehub</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,20 @@
         <version>${casehub.version}</version>
       </dependency>
 
+      <!-- casehub-platform-expression — JQEvaluator bean (required by casehub-engine since engine#316) -->
+      <dependency>
+        <groupId>io.casehub</groupId>
+        <artifactId>casehub-platform-expression</artifactId>
+        <version>${casehub.version}</version>
+      </dependency>
+
+      <!-- casehub-platform — MockPreferenceProvider @DefaultBean (required by casehub-work) -->
+      <dependency>
+        <groupId>io.casehub</groupId>
+        <artifactId>casehub-platform</artifactId>
+        <version>${casehub.version}</version>
+      </dependency>
+
       <!-- AssertJ — test assertion library for all devtown modules -->
       <dependency>
         <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,15 @@
     </dependencies>
   </dependencyManagement>
 
+  <repositories>
+    <repository>
+      <id>github</id>
+      <name>casehubio GitHub Packages</name>
+      <url>https://maven.pkg.github.com/casehubio/*</url>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
+
   <distributionManagement>
     <repository>
       <id>github</id>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,13 @@
         <version>${casehub.version}</version>
       </dependency>
 
+      <!-- casehub-engine runtime — needed by app/ for YamlCaseHub CDI wiring -->
+      <dependency>
+        <groupId>io.casehub</groupId>
+        <artifactId>casehub-engine</artifactId>
+        <version>${casehub.version}</version>
+      </dependency>
+
       <!-- casehub-qhorus-api — not in casehub-parent BOM -->
       <dependency>
         <groupId>io.casehub</groupId>

--- a/review/pom.xml
+++ b/review/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>casehub-work-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/review/pom.xml
+++ b/review/pom.xml
@@ -35,6 +35,11 @@
       <groupId>io.casehub</groupId>
       <artifactId>casehub-work-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/review/src/main/java/io/casehub/devtown/review/PrFinding.java
+++ b/review/src/main/java/io/casehub/devtown/review/PrFinding.java
@@ -1,0 +1,3 @@
+package io.casehub.devtown.review;
+
+public record PrFinding(String source, String description) {}

--- a/review/src/main/java/io/casehub/devtown/review/PrPayload.java
+++ b/review/src/main/java/io/casehub/devtown/review/PrPayload.java
@@ -1,3 +1,3 @@
-package io.casehub.devtown.app;
+package io.casehub.devtown.review;
 
 public record PrPayload(String repo, int prNumber, String headSha, int linesChanged) {}

--- a/review/src/main/java/io/casehub/devtown/review/PrPayload.java
+++ b/review/src/main/java/io/casehub/devtown/review/PrPayload.java
@@ -1,3 +1,3 @@
 package io.casehub.devtown.review;
 
-public record PrPayload(String repo, int prNumber, String headSha, int linesChanged) {}
+public record PrPayload(String repo, int prNumber, String headSha, String baseRef, int linesChanged) {}

--- a/review/src/main/java/io/casehub/devtown/review/PrReviewApplicationService.java
+++ b/review/src/main/java/io/casehub/devtown/review/PrReviewApplicationService.java
@@ -1,4 +1,4 @@
-package io.casehub.devtown.app;
+package io.casehub.devtown.review;
 
 public interface PrReviewApplicationService {
     PrReviewOutcome review(PrPayload pr);

--- a/review/src/main/java/io/casehub/devtown/review/PrReviewOutcome.java
+++ b/review/src/main/java/io/casehub/devtown/review/PrReviewOutcome.java
@@ -1,4 +1,4 @@
-package io.casehub.devtown.app;
+package io.casehub.devtown.review;
 
 import java.util.List;
 

--- a/review/src/main/java/io/casehub/devtown/review/PrReviewOutcome.java
+++ b/review/src/main/java/io/casehub/devtown/review/PrReviewOutcome.java
@@ -2,4 +2,4 @@ package io.casehub.devtown.review;
 
 import java.util.List;
 
-public record PrReviewOutcome(String verdict, List<String> findings) {}
+public record PrReviewOutcome(String verdict, List<PrFinding> findings) {}

--- a/review/src/main/java/io/casehub/devtown/review/PrVerdict.java
+++ b/review/src/main/java/io/casehub/devtown/review/PrVerdict.java
@@ -1,0 +1,11 @@
+package io.casehub.devtown.review;
+
+public final class PrVerdict {
+
+    public static final String REVIEWED          = "reviewed";
+    public static final String APPROVED          = "approved";
+    public static final String CHANGES_REQUESTED = "changes-requested";
+    public static final String DECLINED          = "declined";
+
+    private PrVerdict() {}
+}

--- a/review/src/main/resources/devtown/pr-review.yaml
+++ b/review/src/main/resources/devtown/pr-review.yaml
@@ -128,7 +128,7 @@ spec:
       when: ".pr.linesChanged > .policy.humanApprovalThreshold and .humanApproval == null"
       humanTask:
         title: "PR approval required"
-        outputMapping: "{ humanApproval: { status: .decision } }"
+        outputMapping: "{ humanApproval: . }"
 
     ## Group 4: Merge — fires when all conditions satisfied
     - name: merge

--- a/review/src/main/resources/devtown/pr-review.yaml
+++ b/review/src/main/resources/devtown/pr-review.yaml
@@ -128,6 +128,8 @@ spec:
       when: ".pr.linesChanged > .policy.humanApprovalThreshold and .humanApproval == null"
       humanTask:
         title: "PR approval required"
+        candidateGroups: [pr-reviewers]
+        expiresIn: PT24H
         outputMapping: "{ humanApproval: . }"
 
     ## Group 4: Merge — fires when all conditions satisfied

--- a/review/src/main/resources/devtown/pr-review.yaml
+++ b/review/src/main/resources/devtown/pr-review.yaml
@@ -58,7 +58,7 @@ spec:
     - name: pr-approved
       kind: success
       condition: >-
-        .securityReview.outcome == "APPROVED" and
+        (.codeAnalysis.securitySensitive == false or .securityReview.outcome == "APPROVED") and
         (.codeAnalysis.architectureCrossing == false or .architectureReview.outcome == "APPROVED") and
         .styleCheck.outcome == "APPROVED" and
         .testCoverage.outcome == "APPROVED" and
@@ -137,7 +137,7 @@ spec:
     - name: merge
       on: { contextChange: {} }
       when: >-
-        .securityReview.outcome == "APPROVED" and
+        (.codeAnalysis.securitySensitive == false or .securityReview.outcome == "APPROVED") and
         (.codeAnalysis.architectureCrossing == false or .architectureReview.outcome == "APPROVED") and
         .styleCheck.outcome == "APPROVED" and
         .testCoverage.outcome == "APPROVED" and

--- a/review/src/main/resources/devtown/pr-review.yaml
+++ b/review/src/main/resources/devtown/pr-review.yaml
@@ -43,11 +43,6 @@ spec:
       inputSchema: "{ pr: .pr }"
       outputSchema: "{ ci: { status: . } }"
 
-    - name: "human-decision:pr-approval"
-      description: "Human senior architect approval gate"
-      inputSchema: "{ pr: .pr }"
-      outputSchema: "{ humanApproval: { status: . } }"
-
     - name: merge-executor
       description: "Executes the merge when all goals are satisfied"
       inputSchema: "{ pr: .pr }"
@@ -131,7 +126,9 @@ spec:
     - name: human-approval
       on: { contextChange: {} }
       when: ".pr.linesChanged > .policy.humanApprovalThreshold and .humanApproval == null"
-      capability: "human-decision:pr-approval"
+      humanTask:
+        title: "PR approval required"
+        outputMapping: "{ humanApproval: { status: .decision } }"
 
     ## Group 4: Merge — fires when all conditions satisfied
     - name: merge

--- a/review/src/main/resources/devtown/pr-review.yaml
+++ b/review/src/main/resources/devtown/pr-review.yaml
@@ -1,0 +1,148 @@
+dsl: "0.1"
+version: "1.0.0"
+name: pr-review
+namespace: devtown
+title: PR Review — content-driven routing and parallel checks
+expressionLang: jq
+
+spec:
+
+  ## ─── Capabilities ──────────────────────────────────────────────────
+  capabilities:
+    - name: code-analysis
+      description: "Characterises the code: crypto, auth, cross-API changes, scope"
+      inputSchema: "{ pr: .pr }"
+      outputSchema: "{ codeAnalysis: . }"
+
+    - name: security-review
+      description: "Security specialist review — fires only on security-sensitive code"
+      inputSchema: "{ pr: .pr, codeAnalysis: .codeAnalysis }"
+      outputSchema: "{ securityReview: { outcome: . } }"
+
+    - name: architecture-review
+      description: "Architecture review — fires only when cross-API changes are detected"
+      inputSchema: "{ pr: .pr, codeAnalysis: .codeAnalysis }"
+      outputSchema: "{ architectureReview: { outcome: . } }"
+
+    - name: style-review
+      description: "Style and formatting check"
+      inputSchema: "{ pr: .pr }"
+      outputSchema: "{ styleCheck: { outcome: . } }"
+
+    - name: test-coverage
+      description: "Test coverage analysis"
+      inputSchema: "{ pr: .pr }"
+      outputSchema: "{ testCoverage: { outcome: . } }"
+
+    - name: performance-analysis
+      description: "Performance impact analysis"
+      inputSchema: "{ pr: .pr }"
+      outputSchema: "{ performanceAnalysis: { outcome: . } }"
+
+    - name: ci-runner
+      description: "Runs the CI suite for the PR"
+      inputSchema: "{ pr: .pr }"
+      outputSchema: "{ ci: { status: . } }"
+
+    - name: "human-decision:pr-approval"
+      description: "Human senior architect approval gate"
+      inputSchema: "{ pr: .pr }"
+      outputSchema: "{ humanApproval: { status: . } }"
+
+    - name: merge-executor
+      description: "Executes the merge when all goals are satisfied"
+      inputSchema: "{ pr: .pr }"
+      outputSchema: "{}"
+
+  ## ─── Goals ──────────────────────────────────────────────────────────
+  goals:
+    - name: pr-approved
+      kind: success
+      condition: >-
+        .securityReview.outcome == "APPROVED" and
+        (.codeAnalysis.architectureCrossing == false or .architectureReview.outcome == "APPROVED") and
+        .styleCheck.outcome == "APPROVED" and
+        .testCoverage.outcome == "APPROVED" and
+        .performanceAnalysis.outcome == "APPROVED"
+
+    - name: security-verified
+      kind: success
+      condition: >-
+        .codeAnalysis.securitySensitive == false or
+        .securityReview.outcome == "APPROVED"
+
+    - name: ci-passing
+      kind: success
+      condition: '.ci.status == "passing"'
+
+  completion:
+    success:
+      allOf:
+        - pr-approved
+        - security-verified
+        - ci-passing
+
+  ## ─── Bindings ────────────────────────────────────────────────────────
+  bindings:
+
+    ## Group 1: Entry — fire immediately when PR arrives
+    - name: initial-analysis
+      on: { contextChange: {} }
+      when: ".pr != null and .codeAnalysis == null"
+      capability: code-analysis
+
+    - name: run-ci
+      on: { contextChange: {} }
+      when: ".pr != null and .ci == null"
+      capability: ci-runner
+
+    ## Group 2: Content-driven — fire after analysis, all in parallel
+    - name: security-review
+      on: { contextChange: {} }
+      when: >-
+        .codeAnalysis.complete == true and
+        .codeAnalysis.securitySensitive == true and
+        .securityReview == null
+      capability: security-review
+
+    - name: architecture-review
+      on: { contextChange: {} }
+      when: >-
+        .codeAnalysis.complete == true and
+        .codeAnalysis.architectureCrossing == true and
+        .architectureReview == null
+      capability: architecture-review
+
+    - name: style-check
+      on: { contextChange: {} }
+      when: ".codeAnalysis.complete == true and .styleCheck == null"
+      capability: style-review
+
+    - name: test-coverage
+      on: { contextChange: {} }
+      when: ".codeAnalysis.complete == true and .testCoverage == null"
+      capability: test-coverage
+
+    - name: performance-analysis
+      on: { contextChange: {} }
+      when: ".codeAnalysis.complete == true and .performanceAnalysis == null"
+      capability: performance-analysis
+
+    ## Group 3: Human gate — fires alongside CI when PR exceeds threshold
+    - name: human-approval
+      on: { contextChange: {} }
+      when: ".pr.linesChanged > .policy.humanApprovalThreshold and .humanApproval == null"
+      capability: "human-decision:pr-approval"
+
+    ## Group 4: Merge — fires when all conditions satisfied
+    - name: merge
+      on: { contextChange: {} }
+      when: >-
+        .securityReview.outcome == "APPROVED" and
+        (.codeAnalysis.architectureCrossing == false or .architectureReview.outcome == "APPROVED") and
+        .styleCheck.outcome == "APPROVED" and
+        .testCoverage.outcome == "APPROVED" and
+        .performanceAnalysis.outcome == "APPROVED" and
+        (.pr.linesChanged <= .policy.humanApprovalThreshold or .humanApproval.status == "approved") and
+        .ci.status == "passing"
+      capability: merge-executor

--- a/review/src/main/resources/devtown/pr-review.yaml
+++ b/review/src/main/resources/devtown/pr-review.yaml
@@ -3,7 +3,6 @@ version: "1.0.0"
 name: pr-review
 namespace: devtown
 title: PR Review — content-driven routing and parallel checks
-expressionLang: jq
 
 spec:
 

--- a/review/src/test/java/io/casehub/devtown/review/MapCaseContext.java
+++ b/review/src/test/java/io/casehub/devtown/review/MapCaseContext.java
@@ -212,8 +212,4 @@ class MapCaseContext implements CaseContext {
     throw new UnsupportedOperationException();
   }
 
-  @Override
-  public Map<String, Object> evalObjectTemplate(String template) {
-    throw new UnsupportedOperationException();
-  }
 }

--- a/review/src/test/java/io/casehub/devtown/review/MapCaseContext.java
+++ b/review/src/test/java/io/casehub/devtown/review/MapCaseContext.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.devtown.review;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.context.CaseContext;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Test-only CaseContext backed by a flat Map&lt;String, Object&gt;.
+ * Supports get(), contains(), and getPath() for nested access.
+ * All other methods throw UnsupportedOperationException.
+ */
+class MapCaseContext implements CaseContext {
+
+  private final Map<String, Object> data;
+
+  MapCaseContext(Map<String, Object> data) {
+    this.data = data;
+  }
+
+  @Override
+  public Map<String, Object> getData() {
+    return data;
+  }
+
+  @Override
+  public Object get(String key) {
+    return data.get(key);
+  }
+
+  @Override
+  public boolean contains(String key) {
+    return data.containsKey(key);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Object getPath(String path) {
+    String[] parts = path.split("\\.", 2);
+    Object val = data.get(parts[0]);
+    if (parts.length == 1 || val == null) {
+      return val;
+    }
+    if (val instanceof Map<?, ?> m) {
+      return new MapCaseContext((Map<String, Object>) m).getPath(parts[1]);
+    }
+    return null;
+  }
+
+  // ── Stubs ──────────────────────────────────────────────────────────
+
+  @Override
+  public CaseContext set(String key, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> T getAs(String key, Class<T> type) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> T getOrDefault(String key, T defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Object computeIfAbsent(String key, Function<String, Object> mappingFunction) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Object putIfAbsent(String key, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean compareAndSet(String key, Object expected, Object newValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CaseContext update(String key, Function<Object, Object> updateFunction) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getString(String key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Integer getInt(String key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Long getLong(String key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Double getDouble(String key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Boolean getBoolean(String key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> List<T> getList(String key, Class<T> elementType) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getPathAsString(String path) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CaseContext setPath(String path, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Optional<JsonNode> applyAndDiff(String path, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CaseContext setAll(Map<String, Object> values) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Map<String, Object> getAll(String... keys) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CaseContext remove(String key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CaseContext clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Set<String> getKeys() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int size() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public JsonNode asJsonNode() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CaseContext merge(CaseContext other) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CaseContext snapshot() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public JsonNode diff(CaseContext other) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void applyDiff(JsonNode diff) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getVersion() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Map<String, Object> evalObjectTemplate(String template) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/review/src/test/java/io/casehub/devtown/review/PrReviewBindingConditionTest.java
+++ b/review/src/test/java/io/casehub/devtown/review/PrReviewBindingConditionTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.devtown.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PrReviewBindingConditionTest {
+
+    private static final int THRESHOLD = 500;
+    private CaseDefinition def;
+
+    @BeforeEach
+    void setup() {
+        def = PrReviewCaseDefinition.build(THRESHOLD);
+    }
+
+    private LambdaExpressionEvaluator condition(String bindingName) {
+        return def.getBindings().stream()
+            .filter(b -> b.getName().equals(bindingName))
+            .findFirst()
+            .map(b -> (LambdaExpressionEvaluator) b.getWhen())
+            .orElseThrow(() -> new AssertionError("Binding not found: " + bindingName));
+    }
+
+    private MapCaseContext ctx(Map<String, Object> data) {
+        return new MapCaseContext(data);
+    }
+
+    private Map<String, Object> pr(int linesChanged) {
+        return Map.of("id", "42", "repo", "casehubio/devtown",
+            "linesChanged", linesChanged, "baseRef", "main", "headSha", "abc123");
+    }
+
+    private Map<String, Object> policy() {
+        return Map.of("humanApprovalThreshold", THRESHOLD);
+    }
+
+    private Map<String, Object> analysis(boolean securitySensitive, boolean architectureCrossing) {
+        return Map.of("complete", true,
+            "securitySensitive", securitySensitive,
+            "architectureCrossing", architectureCrossing);
+    }
+
+    @Nested class InitialAnalysis {
+        @Test void fires_whenPrArrivesAndNoAnalysis() {
+            assertThat(condition("initial-analysis").test(ctx(Map.of("pr", pr(100))))).isTrue();
+        }
+        @Test void doesNotFire_whenAnalysisAlreadyPresent() {
+            assertThat(condition("initial-analysis").test(ctx(Map.of(
+                "pr", pr(100), "codeAnalysis", analysis(false, false))))).isFalse();
+        }
+        @Test void doesNotFire_whenNoPr() {
+            assertThat(condition("initial-analysis").test(ctx(Map.of()))).isFalse();
+        }
+    }
+
+    @Nested class RunCi {
+        @Test void fires_whenPrArrivesAndNoCi() {
+            assertThat(condition("run-ci").test(ctx(Map.of("pr", pr(100))))).isTrue();
+        }
+        @Test void doesNotFire_whenCiAlreadyPresent() {
+            assertThat(condition("run-ci").test(ctx(Map.of(
+                "pr", pr(100), "ci", Map.of("status", "pending"))))).isFalse();
+        }
+    }
+
+    @Nested class SecurityReview {
+        @Test void fires_whenAnalysisCompleteAndSecuritySensitive() {
+            assertThat(condition("security-review").test(ctx(Map.of(
+                "pr", pr(100), "codeAnalysis", analysis(true, false))))).isTrue();
+        }
+        @Test void doesNotFire_whenNotSecuritySensitive() {
+            assertThat(condition("security-review").test(ctx(Map.of(
+                "pr", pr(100), "codeAnalysis", analysis(false, false))))).isFalse();
+        }
+        @Test void doesNotFire_whenAlreadyReviewed() {
+            assertThat(condition("security-review").test(ctx(Map.of(
+                "pr", pr(100),
+                "codeAnalysis", analysis(true, false),
+                "securityReview", Map.of("outcome", "APPROVED"))))).isFalse();
+        }
+        @Test void doesNotFire_whenAnalysisNotComplete() {
+            assertThat(condition("security-review").test(ctx(Map.of(
+                "pr", pr(100),
+                "codeAnalysis", Map.of("complete", false,
+                    "securitySensitive", true, "architectureCrossing", false))))).isFalse();
+        }
+    }
+
+    @Nested class ArchitectureReview {
+        @Test void fires_whenAnalysisCompleteAndArchitectureCrossing() {
+            assertThat(condition("architecture-review").test(ctx(Map.of(
+                "pr", pr(100), "codeAnalysis", analysis(false, true))))).isTrue();
+        }
+        @Test void doesNotFire_whenNoArchitectureCrossing() {
+            assertThat(condition("architecture-review").test(ctx(Map.of(
+                "pr", pr(100), "codeAnalysis", analysis(false, false))))).isFalse();
+        }
+        @Test void doesNotFire_whenAlreadyReviewed() {
+            assertThat(condition("architecture-review").test(ctx(Map.of(
+                "pr", pr(100),
+                "codeAnalysis", analysis(false, true),
+                "architectureReview", Map.of("outcome", "APPROVED"))))).isFalse();
+        }
+    }
+
+    @Nested class ParallelChecks {
+        @Test void styleCheck_fires_whenAnalysisComplete() {
+            assertThat(condition("style-check").test(ctx(Map.of(
+                "pr", pr(100), "codeAnalysis", analysis(false, false))))).isTrue();
+        }
+        @Test void styleCheck_doesNotFire_whenAlreadyDone() {
+            assertThat(condition("style-check").test(ctx(Map.of(
+                "pr", pr(100),
+                "codeAnalysis", analysis(false, false),
+                "styleCheck", Map.of("outcome", "APPROVED"))))).isFalse();
+        }
+        @Test void testCoverage_fires_whenAnalysisComplete() {
+            assertThat(condition("test-coverage").test(ctx(Map.of(
+                "pr", pr(100), "codeAnalysis", analysis(false, false))))).isTrue();
+        }
+        @Test void performanceAnalysis_fires_whenAnalysisComplete() {
+            assertThat(condition("performance-analysis").test(ctx(Map.of(
+                "pr", pr(100), "codeAnalysis", analysis(false, false))))).isTrue();
+        }
+    }
+
+    @Nested class HumanApproval {
+        @Test void fires_whenLinesExceedThreshold() {
+            assertThat(condition("human-approval").test(ctx(Map.of(
+                "pr", pr(THRESHOLD + 1), "policy", policy())))).isTrue();
+        }
+        @Test void doesNotFire_whenLinesAtThreshold() {
+            assertThat(condition("human-approval").test(ctx(Map.of(
+                "pr", pr(THRESHOLD), "policy", policy())))).isFalse();
+        }
+        @Test void doesNotFire_whenLinesBelow() {
+            assertThat(condition("human-approval").test(ctx(Map.of(
+                "pr", pr(100), "policy", policy())))).isFalse();
+        }
+        @Test void doesNotFire_whenAlreadyApproved() {
+            assertThat(condition("human-approval").test(ctx(Map.of(
+                "pr", pr(THRESHOLD + 1),
+                "policy", policy(),
+                "humanApproval", Map.of("status", "approved"))))).isFalse();
+        }
+    }
+
+    @Nested class Merge {
+        private Map<String, Object> allApproved() {
+            return Map.of(
+                "pr", pr(100),
+                "policy", policy(),
+                "codeAnalysis", analysis(false, false),
+                "securityReview", Map.of("outcome", "APPROVED"),
+                "styleCheck", Map.of("outcome", "APPROVED"),
+                "testCoverage", Map.of("outcome", "APPROVED"),
+                "performanceAnalysis", Map.of("outcome", "APPROVED"),
+                "ci", Map.of("status", "passing")
+            );
+        }
+
+        @Test void fires_whenAllConditionsSatisfied_noArchCrossing_noHumanRequired() {
+            assertThat(condition("merge").test(ctx(allApproved()))).isTrue();
+        }
+        @Test void doesNotFire_whenCiNotPassing() {
+            var data = new java.util.HashMap<>(allApproved());
+            data.put("ci", Map.of("status", "failing"));
+            assertThat(condition("merge").test(ctx(data))).isFalse();
+        }
+        @Test void doesNotFire_whenStyleCheckNotApproved() {
+            var data = new java.util.HashMap<>(allApproved());
+            data.put("styleCheck", Map.of("outcome", "FAILED"));
+            assertThat(condition("merge").test(ctx(data))).isFalse();
+        }
+        @Test void doesNotFire_whenArchCrossingAndNoArchReview() {
+            var data = new java.util.HashMap<>(allApproved());
+            data.put("codeAnalysis", analysis(false, true));
+            assertThat(condition("merge").test(ctx(data))).isFalse();
+        }
+        @Test void fires_whenArchCrossingAndArchReviewApproved() {
+            var data = new java.util.HashMap<>(allApproved());
+            data.put("codeAnalysis", analysis(false, true));
+            data.put("architectureReview", Map.of("outcome", "APPROVED"));
+            assertThat(condition("merge").test(ctx(data))).isTrue();
+        }
+        @Test void doesNotFire_whenHumanRequiredButNotApproved() {
+            var data = new java.util.HashMap<>(allApproved());
+            data.put("pr", pr(THRESHOLD + 1));
+            assertThat(condition("merge").test(ctx(data))).isFalse();
+        }
+        @Test void fires_whenHumanRequiredAndApproved() {
+            var data = new java.util.HashMap<>(allApproved());
+            data.put("pr", pr(THRESHOLD + 1));
+            data.put("humanApproval", Map.of("status", "approved"));
+            assertThat(condition("merge").test(ctx(data))).isTrue();
+        }
+        @Test void fires_whenNotSecuritySensitiveAndNoSecurityReview() {
+            var data = new java.util.HashMap<>(allApproved());
+            data.remove("securityReview");
+            // codeAnalysis already has securitySensitive=false in allApproved() via analysis(false, false)
+            assertThat(condition("merge").test(ctx(data))).isTrue();
+        }
+    }
+}

--- a/review/src/test/java/io/casehub/devtown/review/PrReviewBindingConditionTest.java
+++ b/review/src/test/java/io/casehub/devtown/review/PrReviewBindingConditionTest.java
@@ -151,6 +151,12 @@ class PrReviewBindingConditionTest {
             assertThat(condition("test-coverage").test(ctx(Map.of(
                 "pr", pr(100), "codeAnalysis", analysis(false, false))))).isTrue();
         }
+        @Test void testCoverage_doesNotFire_whenAlreadyDone() {
+            assertThat(condition("test-coverage").test(ctx(Map.of(
+                "pr", pr(100),
+                "codeAnalysis", analysis(false, false),
+                "testCoverage", Map.of("outcome", "APPROVED"))))).isFalse();
+        }
         @Test void testCoverage_doesNotFire_whenAnalysisNotComplete() {
             assertThat(condition("test-coverage").test(ctx(Map.of(
                 "pr", pr(100),
@@ -160,6 +166,12 @@ class PrReviewBindingConditionTest {
         @Test void performanceAnalysis_fires_whenAnalysisComplete() {
             assertThat(condition("performance-analysis").test(ctx(Map.of(
                 "pr", pr(100), "codeAnalysis", analysis(false, false))))).isTrue();
+        }
+        @Test void performanceAnalysis_doesNotFire_whenAlreadyDone() {
+            assertThat(condition("performance-analysis").test(ctx(Map.of(
+                "pr", pr(100),
+                "codeAnalysis", analysis(false, false),
+                "performanceAnalysis", Map.of("outcome", "APPROVED"))))).isFalse();
         }
         @Test void performanceAnalysis_doesNotFire_whenAnalysisNotComplete() {
             assertThat(condition("performance-analysis").test(ctx(Map.of(

--- a/review/src/test/java/io/casehub/devtown/review/PrReviewBindingConditionTest.java
+++ b/review/src/test/java/io/casehub/devtown/review/PrReviewBindingConditionTest.java
@@ -122,6 +122,12 @@ class PrReviewBindingConditionTest {
                 "codeAnalysis", analysis(false, true),
                 "architectureReview", Map.of("outcome", "APPROVED"))))).isFalse();
         }
+        @Test void doesNotFire_whenAnalysisNotComplete() {
+            assertThat(condition("architecture-review").test(ctx(Map.of(
+                "pr", pr(100),
+                "codeAnalysis", Map.of("complete", false,
+                    "securitySensitive", false, "architectureCrossing", true))))).isFalse();
+        }
     }
 
     @Nested class ParallelChecks {
@@ -135,13 +141,31 @@ class PrReviewBindingConditionTest {
                 "codeAnalysis", analysis(false, false),
                 "styleCheck", Map.of("outcome", "APPROVED"))))).isFalse();
         }
+        @Test void styleCheck_doesNotFire_whenAnalysisNotComplete() {
+            assertThat(condition("style-check").test(ctx(Map.of(
+                "pr", pr(100),
+                "codeAnalysis", Map.of("complete", false,
+                    "securitySensitive", false, "architectureCrossing", false))))).isFalse();
+        }
         @Test void testCoverage_fires_whenAnalysisComplete() {
             assertThat(condition("test-coverage").test(ctx(Map.of(
                 "pr", pr(100), "codeAnalysis", analysis(false, false))))).isTrue();
         }
+        @Test void testCoverage_doesNotFire_whenAnalysisNotComplete() {
+            assertThat(condition("test-coverage").test(ctx(Map.of(
+                "pr", pr(100),
+                "codeAnalysis", Map.of("complete", false,
+                    "securitySensitive", false, "architectureCrossing", false))))).isFalse();
+        }
         @Test void performanceAnalysis_fires_whenAnalysisComplete() {
             assertThat(condition("performance-analysis").test(ctx(Map.of(
                 "pr", pr(100), "codeAnalysis", analysis(false, false))))).isTrue();
+        }
+        @Test void performanceAnalysis_doesNotFire_whenAnalysisNotComplete() {
+            assertThat(condition("performance-analysis").test(ctx(Map.of(
+                "pr", pr(100),
+                "codeAnalysis", Map.of("complete", false,
+                    "securitySensitive", false, "architectureCrossing", false))))).isFalse();
         }
     }
 

--- a/review/src/test/java/io/casehub/devtown/review/PrReviewCaseDefinition.java
+++ b/review/src/test/java/io/casehub/devtown/review/PrReviewCaseDefinition.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.devtown.review;
+
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
+import io.casehub.devtown.domain.AgentQualification;
+import io.casehub.devtown.domain.HumanDecision;
+import io.casehub.devtown.domain.ReviewDomain;
+import java.util.List;
+
+/**
+ * Fluent DSL factory for the PR review case definition.
+ *
+ * <p>Produces the same logical structure as devtown/pr-review.yaml but uses
+ * {@link LambdaExpressionEvaluator} for binding conditions — enabling pure unit
+ * tests without YAML parsing or a Quarkus context.
+ */
+final class PrReviewCaseDefinition {
+
+    private PrReviewCaseDefinition() {}
+
+    static CaseDefinition build(int humanApprovalThreshold) {
+        var codeAnalysisCap   = cap(ReviewDomain.CODE_ANALYSIS);
+        var securityReviewCap = cap(ReviewDomain.SECURITY_REVIEW);
+        var archReviewCap     = cap(ReviewDomain.ARCHITECTURE_REVIEW);
+        var styleReviewCap    = cap(ReviewDomain.STYLE_REVIEW);
+        var testCoverageCap   = cap(ReviewDomain.TEST_COVERAGE);
+        var perfAnalysisCap   = cap(ReviewDomain.PERFORMANCE_ANALYSIS);
+        var ciRunnerCap       = cap(AgentQualification.CI_RUNNER);
+        var humanDecisionCap  = cap(HumanDecision.PR_APPROVAL);
+        var mergeExecutorCap  = cap(AgentQualification.MERGE_EXECUTOR);
+
+        // Goals — use Goal.builder().condition(Predicate) which wraps in LambdaExpressionEvaluator
+        var prApproved = Goal.builder()
+            .name("pr-approved")
+            .kind(GoalKind.SUCCESS)
+            .condition(ctx ->
+                (Boolean.FALSE.equals(ctx.getPath("codeAnalysis.securitySensitive")) ||
+                    "APPROVED".equals(ctx.getPath("securityReview.outcome"))) &&
+                (Boolean.FALSE.equals(ctx.getPath("codeAnalysis.architectureCrossing")) ||
+                    "APPROVED".equals(ctx.getPath("architectureReview.outcome"))) &&
+                "APPROVED".equals(ctx.getPath("styleCheck.outcome")) &&
+                "APPROVED".equals(ctx.getPath("testCoverage.outcome")) &&
+                "APPROVED".equals(ctx.getPath("performanceAnalysis.outcome")))
+            .build();
+
+        var securityVerified = Goal.builder()
+            .name("security-verified")
+            .kind(GoalKind.SUCCESS)
+            .condition(ctx ->
+                Boolean.FALSE.equals(ctx.getPath("codeAnalysis.securitySensitive")) ||
+                "APPROVED".equals(ctx.getPath("securityReview.outcome")))
+            .build();
+
+        var ciPassing = Goal.builder()
+            .name("ci-passing")
+            .kind(GoalKind.SUCCESS)
+            .condition(ctx -> "passing".equals(ctx.getPath("ci.status")))
+            .build();
+
+        // Trigger: fire on any context change (null filter = unconditional)
+        var trigger = new ContextChangeTrigger((io.casehub.api.model.evaluator.ExpressionEvaluator) null);
+
+        CaseDefinition def = CaseDefinition.builder()
+            .namespace("devtown")
+            .name("pr-review")
+            .version("1.0.0")
+            .completion(GoalExpression.allOf(prApproved, securityVerified, ciPassing))
+            .build();
+
+        def.getCapabilities().addAll(List.of(
+            codeAnalysisCap, securityReviewCap, archReviewCap,
+            styleReviewCap, testCoverageCap, perfAnalysisCap,
+            ciRunnerCap, humanDecisionCap, mergeExecutorCap));
+
+        def.getGoals().addAll(List.of(prApproved, securityVerified, ciPassing));
+
+        // Group 1: Entry — fire immediately on PR arrival
+        def.getBindings().add(Binding.builder().name("initial-analysis").on(trigger)
+            .when(new LambdaExpressionEvaluator(
+                ctx -> ctx.get("pr") != null && ctx.get("codeAnalysis") == null))
+            .capability(codeAnalysisCap).build());
+
+        def.getBindings().add(Binding.builder().name("run-ci").on(trigger)
+            .when(new LambdaExpressionEvaluator(
+                ctx -> ctx.get("pr") != null && ctx.get("ci") == null))
+            .capability(ciRunnerCap).build());
+
+        // Group 2: Content-driven — fire once analysis results arrive
+        def.getBindings().add(Binding.builder().name("security-review").on(trigger)
+            .when(new LambdaExpressionEvaluator(ctx ->
+                Boolean.TRUE.equals(ctx.getPath("codeAnalysis.complete")) &&
+                Boolean.TRUE.equals(ctx.getPath("codeAnalysis.securitySensitive")) &&
+                ctx.get("securityReview") == null))
+            .capability(securityReviewCap).build());
+
+        def.getBindings().add(Binding.builder().name("architecture-review").on(trigger)
+            .when(new LambdaExpressionEvaluator(ctx ->
+                Boolean.TRUE.equals(ctx.getPath("codeAnalysis.complete")) &&
+                Boolean.TRUE.equals(ctx.getPath("codeAnalysis.architectureCrossing")) &&
+                ctx.get("architectureReview") == null))
+            .capability(archReviewCap).build());
+
+        def.getBindings().add(Binding.builder().name("style-check").on(trigger)
+            .when(new LambdaExpressionEvaluator(ctx ->
+                Boolean.TRUE.equals(ctx.getPath("codeAnalysis.complete")) &&
+                ctx.get("styleCheck") == null))
+            .capability(styleReviewCap).build());
+
+        def.getBindings().add(Binding.builder().name("test-coverage").on(trigger)
+            .when(new LambdaExpressionEvaluator(ctx ->
+                Boolean.TRUE.equals(ctx.getPath("codeAnalysis.complete")) &&
+                ctx.get("testCoverage") == null))
+            .capability(testCoverageCap).build());
+
+        def.getBindings().add(Binding.builder().name("performance-analysis").on(trigger)
+            .when(new LambdaExpressionEvaluator(ctx ->
+                Boolean.TRUE.equals(ctx.getPath("codeAnalysis.complete")) &&
+                ctx.get("performanceAnalysis") == null))
+            .capability(perfAnalysisCap).build());
+
+        // Group 3: Human gate — threshold-based, fires once regardless of analysis
+        def.getBindings().add(Binding.builder().name("human-approval").on(trigger)
+            .when(new LambdaExpressionEvaluator(ctx -> {
+                Object linesChanged = ctx.getPath("pr.linesChanged");
+                return linesChanged instanceof Number n &&
+                    n.intValue() > humanApprovalThreshold &&
+                    ctx.get("humanApproval") == null;
+            }))
+            .capability(humanDecisionCap).build());
+
+        // Group 4: Merge — all checks must pass; human gate conditional on line count
+        def.getBindings().add(Binding.builder().name("merge").on(trigger)
+            .when(new LambdaExpressionEvaluator(ctx -> {
+                Object linesChanged = ctx.getPath("pr.linesChanged");
+                boolean humanOk =
+                    (linesChanged instanceof Number l && l.intValue() <= humanApprovalThreshold) ||
+                    "approved".equals(ctx.getPath("humanApproval.status"));
+                return (Boolean.FALSE.equals(ctx.getPath("codeAnalysis.securitySensitive")) ||
+                            "APPROVED".equals(ctx.getPath("securityReview.outcome"))) &&
+                    (Boolean.FALSE.equals(ctx.getPath("codeAnalysis.architectureCrossing")) ||
+                        "APPROVED".equals(ctx.getPath("architectureReview.outcome"))) &&
+                    "APPROVED".equals(ctx.getPath("styleCheck.outcome")) &&
+                    "APPROVED".equals(ctx.getPath("testCoverage.outcome")) &&
+                    "APPROVED".equals(ctx.getPath("performanceAnalysis.outcome")) &&
+                    humanOk &&
+                    "passing".equals(ctx.getPath("ci.status"));
+            }))
+            .capability(mergeExecutorCap).build());
+
+        return def;
+    }
+
+    private static Capability cap(String name) {
+        return Capability.builder().name(name).inputSchema("{}").outputSchema("{}").build();
+    }
+}

--- a/review/src/test/java/io/casehub/devtown/review/PrReviewGoalConditionTest.java
+++ b/review/src/test/java/io/casehub/devtown/review/PrReviewGoalConditionTest.java
@@ -1,0 +1,107 @@
+package io.casehub.devtown.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PrReviewGoalConditionTest {
+
+    private static final int THRESHOLD = 500;
+    private CaseDefinition def;
+
+    @BeforeEach
+    void setup() {
+        def = PrReviewCaseDefinition.build(THRESHOLD);
+    }
+
+    private LambdaExpressionEvaluator goalCondition(String goalName) {
+        return def.getGoals().stream()
+            .filter(g -> g.getName().equals(goalName))
+            .findFirst()
+            .map(g -> (LambdaExpressionEvaluator) g.getCondition())
+            .orElseThrow(() -> new AssertionError("Goal not found: " + goalName));
+    }
+
+    private MapCaseContext ctx(Map<String, Object> data) {
+        return new MapCaseContext(data);
+    }
+
+    private Map<String, Object> analysis(boolean securitySensitive, boolean architectureCrossing) {
+        return Map.of("complete", true,
+            "securitySensitive", securitySensitive,
+            "architectureCrossing", architectureCrossing);
+    }
+
+    @Nested class PrApproved {
+        @Test void satisfied_whenAllChecksApproved_noSecurity_noArch() {
+            assertThat(goalCondition("pr-approved").test(ctx(Map.of(
+                "codeAnalysis", analysis(false, false),
+                "styleCheck", Map.of("outcome", "APPROVED"),
+                "testCoverage", Map.of("outcome", "APPROVED"),
+                "performanceAnalysis", Map.of("outcome", "APPROVED"))))).isTrue();
+        }
+        @Test void satisfied_whenSecuritySensitiveAndApproved() {
+            assertThat(goalCondition("pr-approved").test(ctx(Map.of(
+                "codeAnalysis", analysis(true, false),
+                "securityReview", Map.of("outcome", "APPROVED"),
+                "styleCheck", Map.of("outcome", "APPROVED"),
+                "testCoverage", Map.of("outcome", "APPROVED"),
+                "performanceAnalysis", Map.of("outcome", "APPROVED"))))).isTrue();
+        }
+        @Test void notSatisfied_whenSecuritySensitiveAndNotApproved() {
+            assertThat(goalCondition("pr-approved").test(ctx(Map.of(
+                "codeAnalysis", analysis(true, false),
+                "styleCheck", Map.of("outcome", "APPROVED"),
+                "testCoverage", Map.of("outcome", "APPROVED"),
+                "performanceAnalysis", Map.of("outcome", "APPROVED"))))).isFalse();
+        }
+        @Test void satisfied_whenArchCrossingAndReviewApproved() {
+            assertThat(goalCondition("pr-approved").test(ctx(Map.of(
+                "codeAnalysis", analysis(false, true),
+                "architectureReview", Map.of("outcome", "APPROVED"),
+                "styleCheck", Map.of("outcome", "APPROVED"),
+                "testCoverage", Map.of("outcome", "APPROVED"),
+                "performanceAnalysis", Map.of("outcome", "APPROVED"))))).isTrue();
+        }
+        @Test void notSatisfied_whenStyleFailed() {
+            assertThat(goalCondition("pr-approved").test(ctx(Map.of(
+                "codeAnalysis", analysis(false, false),
+                "styleCheck", Map.of("outcome", "FAILED"),
+                "testCoverage", Map.of("outcome", "APPROVED"),
+                "performanceAnalysis", Map.of("outcome", "APPROVED"))))).isFalse();
+        }
+    }
+
+    @Nested class SecurityVerified {
+        @Test void satisfied_whenNotSecuritySensitive() {
+            assertThat(goalCondition("security-verified").test(ctx(Map.of(
+                "codeAnalysis", analysis(false, false))))).isTrue();
+        }
+        @Test void satisfied_whenSecuritySensitiveAndApproved() {
+            assertThat(goalCondition("security-verified").test(ctx(Map.of(
+                "codeAnalysis", analysis(true, false),
+                "securityReview", Map.of("outcome", "APPROVED"))))).isTrue();
+        }
+        @Test void notSatisfied_whenSecuritySensitiveAndNotApproved() {
+            assertThat(goalCondition("security-verified").test(ctx(Map.of(
+                "codeAnalysis", analysis(true, false))))).isFalse();
+        }
+    }
+
+    @Nested class CiPassing {
+        @Test void satisfied_whenCiPassing() {
+            assertThat(goalCondition("ci-passing").test(ctx(Map.of(
+                "ci", Map.of("status", "passing"))))).isTrue();
+        }
+        @Test void notSatisfied_whenCiFailing() {
+            assertThat(goalCondition("ci-passing").test(ctx(Map.of(
+                "ci", Map.of("status", "failing"))))).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
Closes #25, Closes #32

Batch of S/XS issues resolved on one branch:

- **#25** Remove `%test.quarkus.datasource.qhorus.reactive=false` — qhorus#141 shipped; suppression no longer needed. Default datasource `reactive=false` kept (H2, unrelated).
- **#32** Add `doesNotFire_whenAlreadyDone` for `test-coverage` and `performance-analysis` — `style-check` had this test; the other two were missing it.
- **#35** Closed without code — qhorus#172 resolved the duplicate `GET /.well-known` conflict.
- **#37** Closed without code — `evalObjectTemplate` already removed from `MapCaseContext` in prior work.

59 tests, all passing.